### PR TITLE
Add minimax-tts skill note and TTS script

### DIFF
--- a/content/OpenClaw/skill-notes/minimax-tts/SKILL.md
+++ b/content/OpenClaw/skill-notes/minimax-tts/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: minimax-tts
+description: High-quality text-to-speech (TTS) using the MiniMax API (t2a_v2). Use when you want audio output (mp3) from text in any supported language (e.g., 廣東話/粵語, 國語, 英語). Includes Cantonese defaults and supports short clips (<20s).
+metadata: {"openclaw":{"emoji":"🔊","requires":{"bins":["curl","python3"] ,"env":["MINIMAX_API_KEY"]},"primaryEnv":"MINIMAX_API_KEY"}}
+---
+
+Generate short audio via MiniMax TTS (default: <20 seconds).
+
+This skill is not restricted to Cantonese. Cantonese (Yue) is the default profile only.
+If the user requests another language (e.g. 國語 / Mandarin, 英語 / English), generate in that language and choose appropriate `--voice` / `--boost` values.
+
+## Quick use
+
+Create an mp3 (default Cantonese profile):
+
+```bash
+{baseDir}/scripts/tts.sh --text "今晚食咩好？" --output "./out.mp3"
+```
+
+Recommended Cantonese defaults (already set in the script):
+- `--boost "Chinese,Yue"`
+- `--voice "Chinese (Mandarin)_HK_Flight_Attendant"` (HK-accented voice; adjust if you have a better voice_id)
+- These are defaults, not a restriction. For 國語 / Mandarin, 英語 / English, or other languages, override `--voice` and (if useful) `--boost`.
+
+## Workflow (important)
+
+- 先寫好文字，再生成語音 (draft text first, then generate audio).
+- Always review the exact text in a readable form before TTS. The text should visibly include punctuation, spacing, pauses, ellipses, and tone/attitude cues.
+- If the text does not read well on screen, the generated speech usually sounds worse.
+- Practical writing cues for better output:
+  - punctuation for pauses: `，` `。` `？` `！`
+  - spacing / line breaks for rhythm and emphasis
+  - ellipses for hesitation / soft pause: `...` or `……`
+  - interjections / tone words when needed (e.g. `啊`, `啦`, `喎`)
+
+## Configuration
+
+Provide `MINIMAX_API_KEY` via OpenClaw skill env (recommended) or a local `.env` file.
+
+### Option B: .env next to the skill
+Create:
+- `{baseDir}/.env`
+
+With:
+
+```bash
+MINIMAX_API_KEY=...
+```
+
+## Notes / guardrails
+
+- Keep requests short. For the “<20s” default, aim for roughly **<= 80–120 Chinese characters** (depends on speed and punctuation).
+- Use punctuation to control pauses.
+- Follow the user's requested language. Override the default Cantonese-oriented `--voice` / `--boost` when generating 國語 / Mandarin, 英語 / English, or other languages.
+- Store generated files in an organized folder (not project root). Keep the source text and mp3 together using the same base name.
+- Recommended pattern: `generated/minimax-tts/YYYY-MM-DD/HHMMSS-topic-v01.txt` and `.mp3`
+- Create the output directory first (`mkdir -p generated/minimax-tts/YYYY-MM-DD`) before running `tts.sh`.
+- If you need a different voice, pass `--voice <voice_id>`.

--- a/content/OpenClaw/skill-notes/minimax-tts/tts.sh
+++ b/content/OpenClaw/skill-notes/minimax-tts/tts.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Default values (Cantonese/Yue-oriented profile). These are defaults only:
+# callers can override --voice / --boost to generate other languages supported by MiniMax
+# (e.g. 國語/Mandarin, 英語/English).
+MODEL="speech-2.6-turbo"
+VOICE="Chinese (Mandarin)_HK_Flight_Attendant"
+BOOST="Chinese,Yue"
+SPEED=1.0
+MAX_CHARS=120
+VOL=1.0
+PITCH=0
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --text) TEXT="$2"; shift ;;
+        --output) OUTPUT="$2"; shift ;;
+        --model) MODEL="$2"; shift ;;
+        --voice) VOICE="$2"; shift ;;
+        --boost) BOOST="$2"; shift ;;
+        --speed) SPEED="$2"; shift ;;
+        --vol) VOL="$2"; shift ;;
+        --pitch) PITCH="$2"; shift ;;
+        --max-chars) MAX_CHARS="$2"; shift ;;
+    esac
+    shift
+done
+
+if [ -z "$TEXT" ] || [ -z "$OUTPUT" ]; then
+    echo "Usage: $0 --text 'text' --output 'file.mp3' [--model model] [--voice voice] [--boost boost] [--speed speed] [--vol vol] [--pitch pitch] [--max-chars N]"
+    echo "Note: defaults are Cantonese/Yue-oriented; override --voice/--boost for 國語 (Mandarin), 英語 (English), or other languages."
+    exit 1
+fi
+
+# crude length guardrail for short clips (defaults to ~<20s)
+CHAR_COUNT=$(python3 -c 'import sys; s=sys.argv[1] if len(sys.argv)>1 else ""; print(len(s))' "$TEXT" 2>/dev/null || echo 0)
+if [ "$CHAR_COUNT" -gt "$MAX_CHARS" ]; then
+  echo "Error: text too long (${CHAR_COUNT} chars). For short clips, keep <= ${MAX_CHARS} chars (use --max-chars to override)." >&2
+  exit 1
+fi
+
+# Load API Key from .env in the skill directory
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -f "$SKILL_DIR/.env" ]; then
+    export $(grep -v '^#' "$SKILL_DIR/.env" | xargs)
+fi
+
+if [ -z "$MINIMAX_API_KEY" ]; then
+    echo "Error: MINIMAX_API_KEY not found in $SKILL_DIR/.env"
+    exit 1
+fi
+
+# Prepare payload
+PAYLOAD=$(cat <<EOF2
+{
+  "model": "$MODEL",
+  "text": $(echo "$TEXT" | python3 -c "import json, sys; print(json.dumps(sys.stdin.read().strip()))"),
+  "stream": false,
+  "language_boost": "$BOOST",
+  "voice_setting": {
+    "voice_id": "$VOICE",
+    "speed": $SPEED,
+    "vol": $VOL,
+    "pitch": $PITCH
+  },
+  "audio_setting": {
+    "sample_rate": 32000,
+    "bitrate": 128000,
+    "format": "mp3"
+  }
+}
+EOF2
+)
+
+# Call API
+RESPONSE=$(curl -s -X POST "https://api.minimaxi.chat/v1/t2a_v2" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD")
+
+# Extract audio
+echo "$RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+if data.get('data', {}).get('audio'):
+    audio_hex = data['data']['audio']
+    with open('$OUTPUT', 'wb') as f:
+        f.write(bytes.fromhex(audio_hex))
+    sys.exit(0)
+else:
+    print(json.dumps(data, indent=2, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+"


### PR DESCRIPTION
### Motivation
- Provide a reusable MiniMax TTS skill under the OpenClaw notes so users can generate short MP3 clips from text with sensible Cantonese defaults. 
- Surface usage guidance, configuration, and guardrails alongside an executable helper script to simplify adoption.

### Description
- Add `content/OpenClaw/skill-notes/minimax-tts/tts.sh`, a Bash script that parses flags, enforces a short-text guardrail, loads `MINIMAX_API_KEY` from a nearby `.env`, calls the MiniMax `t2a_v2` endpoint, and writes the returned audio hex to an MP3 file. 
- Add `content/OpenClaw/skill-notes/minimax-tts/SKILL.md` with metadata, quick usage examples, workflow tips, configuration options, and guardrails. 
- Ensure `tts.sh` is executable and the files are placed under `content/OpenClaw/skill-notes/minimax-tts` for project consistency.

### Testing
- Verified the new files are present and readable with `nl -ba content/OpenClaw/skill-notes/minimax-tts/tts.sh` and `nl -ba content/OpenClaw/skill-notes/minimax-tts/SKILL.md`, and confirmed their contents; these checks succeeded. 
- Confirmed the `tts.sh` file is executable (`ls -l` / file mode check) and that the script contains the expected argument parsing and API call flow; this check succeeded. 
- No unit tests were added for runtime integration with the MiniMax API, so actual TTS generation was not executed in CI as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6fb3ee3788333945404c25c763b12)