### PR TITLE
Update site branding and add repository source link

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,13 +1,14 @@
 ---
-title: Mr.Chang AI Practice Notebook
+title: AI Study Note
 ---
 
-This site is a personal AI practice notebook.
+This site is an AI study note for engineers.
 
-It records real experiments, setup issues, and working solutions from day-to-day learning and building.
+It captures hands-on experiments, environment setup issues, and practical fixes from daily learning and building.
 
 ## About This Site
 
-- Focus: practical AI learning, not theory-only notes
-- Style: short, implementation-first writeups
+- Focus: practical AI learning and implementation notes
+- Style: concise, build-first writeups
 - Goal: keep reusable references for future projects
+- Source repository: [wahengchang/ai-study-note](https://github.com/wahengchang/ai-study-note)

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -8,7 +8,7 @@ import * as Plugin from "./quartz/plugins"
  */
 const config: QuartzConfig = {
   configuration: {
-    pageTitle: "Mr.Chang AI Practice Notebook",
+    pageTitle: "AI Study Note",
     pageTitleSuffix: "",
     enableSPA: true,
     enablePopovers: true,


### PR DESCRIPTION
### Motivation
- Remove personal branding from the homepage and present the site as a neutral, engineer-focused AI study note.
- Ensure the global Quartz site title matches the new homepage branding.

### Description
- Updated `content/index.md` frontmatter title to "AI Study Note" and rewrote the intro copy to remove the personal name and clarify the site focus.
- Added an explicit source repository link to the homepage pointing to `https://github.com/wahengchang/ai-study-note`.
- Updated `quartz.config.ts` to change the `pageTitle` from "Mr.Chang AI Practice Notebook" to "AI Study Note".

### Testing
- Ran `npm run check`, which failed due to pre-existing TypeScript type errors in `quartz/plugins/transformers/smart-columns.ts` unrelated to these changes.
- Ran `node ./quartz/bootstrap-cli.mjs build --serve`, which failed due to a pre-existing malformed frontmatter in `content/OpenClaw/common-questions/openclaw-cron-session-permission-and-cross-agent-delivery.md` unrelated to these edits.
- No additional automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78b5f545c8333a8a247824a061265)