### PR TITLE
Add 'gog' skill note for Google Workspace CLI

### DIFF
--- a/content/OpenClaw/skill-notes/gog/SKILL.md
+++ b/content/OpenClaw/skill-notes/gog/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: gog
+description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs. Use when the user asks to search/send email, check calendar events, search Drive files, list contacts, read/write Google Sheets, or export/read Google Docs.
+metadata:
+  clawdbot:
+    emoji: "🎮"
+    requires:
+      bins:
+        - gog
+    install:
+      - id: brew
+        kind: brew
+        formula: steipete/tap/gogcli
+        bins:
+          - gog
+        label: "Install gog (brew)"
+---
+
+# gog
+
+Use `gog` for Gmail, Calendar, Drive, Contacts, Sheets, and Docs. Requires OAuth setup.
+
+## Setup (once)
+
+```bash
+gog auth credentials /path/to/client_secret.json
+gog auth add you@gmail.com --services gmail,calendar,drive,contacts,sheets,docs
+gog auth list
+```
+
+## Common Commands
+
+- **Gmail search:** `gog gmail search 'newer_than:7d' --max 10`
+- **Gmail send:** `gog gmail send --to a@b.com --subject "Hi" --body "Hello"`
+- **Calendar events:** `gog calendar events <calendarId> --from <iso> --to <iso>`
+- **Drive search:** `gog drive search "query" --max 10`
+- **Contacts list:** `gog contacts list --max 20`
+- **Sheets get:** `gog sheets get <sheetId> "Tab!A1:D10" --json`
+- **Sheets update:** `gog sheets update <sheetId> "Tab!A1:B2" --values-json '[["A","B"],["1","2"]]' --input USER_ENTERED`
+- **Sheets append:** `gog sheets append <sheetId> "Tab!A:C" --values-json '[["x","y","z"]]' --insert INSERT_ROWS`
+- **Sheets clear:** `gog sheets clear <sheetId> "Tab!A2:Z"`
+- **Sheets metadata:** `gog sheets metadata <sheetId> --json`
+- **Docs export:** `gog docs export <docId> --format txt --out /tmp/doc.txt`
+- **Docs cat:** `gog docs cat <docId>`
+
+## Notes
+
+- Set `GOG_ACCOUNT=you@gmail.com` to avoid repeating `--account`.
+- For scripting, prefer `--json` plus `--no-input`.
+- Sheets values can be passed via `--values-json` (recommended) or as inline rows.
+- Docs supports export/cat/copy. In-place edits require a Docs API client (not in gog).
+- Confirm before sending mail or creating events.


### PR DESCRIPTION
### Motivation
- Add a local skill note that documents the `gog` Google Workspace CLI so agents can discover its capabilities, installation hints, and common usage patterns for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.

### Description
- Create `content/OpenClaw/skill-notes/gog/SKILL.md` containing frontmatter (`name`, `description`, and `clawdbot` metadata with required `gog` binary and Homebrew install hint), OAuth setup steps, a concise list of common `gog` commands, and operational notes for scripting and account configuration.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78af8603083338663fcba03d9b365)