### PR TITLE
docs: prefer chrome://inspect workflow in Chrome DevTools setup note

### DIFF
--- a/content/SetupEnv/setup-chrome-devtools-on-chrome.md
+++ b/content/SetupEnv/setup-chrome-devtools-on-chrome.md
@@ -4,12 +4,13 @@ title: Setup Chrome DevTools for MCP on Chrome (macOS)
 
 ## Goal
 
-Prepare Chrome DevTools so MCP can attach to Chrome for DOM, console, network, and interaction debugging, simple.
+Prepare Chrome DevTools so MCP can attach to Chrome for DOM, console, network, and interaction debugging.
 
 ```mermaid
 flowchart LR
-  A["Open DevTools"] --> B["Start Chrome :9222"]
-  B --> D["Use Elements Console Network"]
+  A["Open DevTools"] --> B["Enable chrome://inspect/#remote-debugging"]
+  B --> C["Confirm 127.0.0.1:9222"]
+  C --> D["Use Elements / Console / Network"]
 ```
 
 ## 1. Open DevTools
@@ -17,10 +18,25 @@ flowchart LR
 - macOS shortcut: `Command + Option + I`
 - Right click on page -> `Inspect`
 - Chrome menu -> `View -> Developer -> Developer Tools`
-![[Chrome with DevTools opened.png]]
-
+  ![[Chrome with DevTools opened.png]]
 
 ## 2. Start Chrome with Remote Debugging (for MCP)
+
+### Option A (recommended): enable from Chrome inspect page
+
+1. Open `chrome://inspect/#remote-debugging`.
+2. Enable `Allow remote debugging for this browser instance`.
+3. Verify Chrome shows: `Server running at: 127.0.0.1:9222`.
+
+Quick verify:
+
+```bash
+curl http://127.0.0.1:9222/json/version
+```
+
+If JSON is returned, MCP can discover browser targets.
+
+### Option B (CLI fallback): launch Chrome with remote debugging port
 
 Close all Chrome windows, then run:
 
@@ -37,6 +53,7 @@ curl http://127.0.0.1:9222/json/version
 If JSON is returned, MCP can discover the browser target.
 
 ![[CodexApp with DevTools opened.png]]
+
 ## 3. Configure useful defaults
 
 Open DevTools settings (`F1` inside DevTools) and set:
@@ -67,14 +84,14 @@ Open DevTools settings (`F1` inside DevTools) and set:
   - Check keyboard shortcut conflicts.
   - Open via menu path instead.
 - MCP cannot connect to Chrome:
+  - Open `chrome://inspect/#remote-debugging` and ensure `Allow remote debugging for this browser instance` is enabled.
+  - Confirm Chrome shows `Server running at: 127.0.0.1:9222`.
   - Make sure Chrome was started with `--remote-debugging-port=9222`.
   - Confirm `http://127.0.0.1:9222/json/version` returns JSON.
 - Network list is empty:
   - Enable `Preserve log`, then reload page.
 - Changes disappear on refresh:
   - Edits in `Elements` are temporary unless saved in source files.
-
-
 
 Official references:
 


### PR DESCRIPTION
### Motivation
- Encourage using the Chrome inspect page (`chrome://inspect/#remote-debugging`) as the recommended way to enable remote debugging for MCP. 
- Make verification and troubleshooting more explicit by surfacing the `127.0.0.1:9222` server indicator and a quick `curl` check. 
- Preserve the existing CLI fallback (`--remote-debugging-port=9222`) for environments where the inspect-page toggle is not available. 

### Description
- Updated `content/SetupEnv/setup-chrome-devtools-on-chrome.md` to prefer the inspect-page workflow and removed redundant wording in the goal. 
- Reworked the Mermaid flowchart to reflect the new sequence: open DevTools → enable `chrome://inspect/#remote-debugging` → confirm `127.0.0.1:9222` → use panels. 
- Added an `Option A (recommended)` section with steps to enable `Allow remote debugging for this browser instance` and a `curl` verification, and kept `Option B` as the CLI fallback. 
- Extended the troubleshooting section to include the inspect-page verification steps. 

### Testing
- Ran `npx prettier content/SetupEnv/setup-chrome-devtools-on-chrome.md --write` and `--check`, and the updated file passed Prettier formatting. 
- Ran repository lint/type checks with `npm run check`, which failed due to pre-existing TypeScript errors in `quartz/plugins/transformers/smart-columns.ts` unrelated to this doc-only change. 
- Verified the note content formatting and layout locally by inspecting the updated Markdown file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea799180c833396abd397426ad4b9)