### PR TITLE
docs: rewrite OpenClaw lifecycle timeline as Mermaid flowchart

### DIFF
--- a/content/OpenClaw/common-questions/openclaw-five-component-lifecycle-analysis.md
+++ b/content/OpenClaw/common-questions/openclaw-five-component-lifecycle-analysis.md
@@ -16,18 +16,26 @@ Understanding how each one initializes, stays active, and reloads/terminates is 
 
 ## 1) Lifecycle Timeline
 
-```text
-Time ------------------------------------------------------------------------------>
+```mermaid
+flowchart LR
+    B[1. Bootstrap
+🟢 Start: openclaw gateway start] --> B2[🔴 End: process exit]
 
-[1. Bootstrap] 🟢 start (openclaw gateway start) ==========================> 🔴 process exit
-       |
-       +--> [2. Identity] 🟢 load + memory-resident (read SKILL.md YAML) ===> 🟡 hot-reload/restart
-                  |
-                  +--> [3. User] 🟢 session created (channel connected) ====> 💾 JSON persisted state
-                             |
-                             +--> [4. Soul] 🟢 dynamic prompt synthesis ======> 🔴 destroyed per turn
-                             |
-                             +--> [5. Tools] ⚙️ invoked on demand ==========> 🔴 process done + heartbeat update
+    B --> I[2. Identity
+🟢 Load SKILL.md YAML + memory resident]
+    I --> I2[🟡 Hot-reload or gateway restart]
+
+    I --> U[3. User
+🟢 Session created when channel connects]
+    U --> U2[💾 JSON persisted state]
+
+    U --> S[4. Soul
+🟢 Dynamic prompt synthesis per turn]
+    S --> S2[🔴 Destroyed after each turn]
+
+    U --> T[5. Tools
+⚙️ Invoked on demand]
+    T --> T2[🔴 Subprocess exits + heartbeat update]
 ```
 
 ## 2) Deep Dive by Component


### PR DESCRIPTION
### Motivation
- Replace a plain-text ASCII timeline with a rendered diagram to improve readability in the Quartz site and make lifecycle branches and start/end states explicit.
- Keep the original five-component sequencing (Bootstrap → Identity → User → Soul/Tools) while making the states easier to scan and maintain.

### Description
- Replaced the text-based block in `content/OpenClaw/common-questions/openclaw-five-component-lifecycle-analysis.md` under "1) Lifecycle Timeline" with a `mermaid` `flowchart LR` diagram.
- Preserved the original component order and semantics while adding explicit start/end nodes and clearer branch connections for each component.
- This is a documentation-only change and does not modify runtime code or behavior.

### Testing
- Ran `npx prettier content/OpenClaw/common-questions/openclaw-five-component-lifecycle-analysis.md --check`, which succeeded and confirmed formatting.
- Ran `npm run check`, which failed due to pre-existing TypeScript errors in `quartz/plugins/transformers/smart-columns.ts` unrelated to this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be44a2b9048333ab5a67f34b884fb4)