### PR TITLE
Change site locale from English (US) to Traditional Chinese

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -18,7 +18,7 @@ const config: QuartzConfig = {
       provider: "google",
       tagId: "G-HQ2GFFXNDD",
     },
-    locale: "en-US",
+    locale: "zh-TW",
     baseUrl: "wahengchang.github.io/ai-study-note",
     ignorePatterns: ["private", "templates", ".obsidian"],
     defaultDateType: "modified",


### PR DESCRIPTION
## Summary
Updated the site locale configuration to support Traditional Chinese (Taiwan) instead of English (US).

## Changes
- Changed `locale` setting from `"en-US"` to `"zh-TW"` in quartz.config.ts

## Details
This change updates the default language and regional settings for the AI study note site to Traditional Chinese (Taiwan). This will affect how dates, numbers, and other locale-dependent content are formatted and displayed throughout the site.

https://claude.ai/code/session_01MfAELV2BYH8DW97ZX7oAJY