### PR TITLE
Add YouTube video link to Claude Code guide

### DIFF
--- a/content/claude-code/learn-claude-code-guide.md
+++ b/content/claude-code/learn-claude-code-guide.md
@@ -13,6 +13,8 @@ tags:
 > 基於 [shareAI-lab/learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) 的 Harness Framework 操作手冊
 > License: MIT ｜ 語言：Python / TypeScript / Markdown
 
+![](https://www.youtube.com/watch?v=EsTrWCV0Ph4)
+
 ---
 
 ## 這篇文章是什麼


### PR DESCRIPTION
## Summary
Added a YouTube video link to the learn-claude-code-guide documentation to provide visual reference material for users.

## Changes
- Embedded YouTube video link (https://www.youtube.com/watch?v=EsTrWCV0Ph4) in the guide introduction section
- Placed the video link after the license and language information for easy discovery

## Details
The video link is added as a markdown image/link element right after the header metadata, providing users with supplementary video content to accompany the written guide.

https://claude.ai/code/session_01L1qC33vHDbDozYN6bXu5D6