### PR TITLE
Update prompt system: frontmatter guidance, media embeds, system-rules ref

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,14 @@ npm run clean                    # Remove macOS ._* files
 ## Writing Rules
 
 1. **File naming**: `kebab-case` for all notes and folders.
-2. **Frontmatter**: Every note requires a `title` field.
+2. **Frontmatter**: Every note requires a `title` field. Recommended: `description` (≤160 chars) and `tags`.
 3. **Syntax**: Standard Markdown + Obsidian wikilinks + Smart Columns (`:::col`).
 4. **Style**: Bullet points, copy-pasteable code blocks, direct headings. No fluff.
 5. **Mermaid**: Use `direction LR` only. Never `TD`. Include only when visualization adds clarity.
 6. **Terminology**: Use precise domain terms (e.g., "p99 latency" not "slow").
+7. **Media embeds**: YouTube videos via `![](https://www.youtube.com/watch?v=VIDEO_ID)`. Supported formats: `youtu.be/`, `youtube.com/watch?v=`, `youtube.com/embed/`.
+
+Full writing governance, tag taxonomy, and frontmatter schema: `docs/system-rules.md`.
 
 ## Prompt System
 
@@ -84,5 +87,6 @@ Reference agents by name when delegating tasks:
 
 - `quartz.config.ts` — Site config, plugins, theme.
 - `quartz.layout.ts` — Page layout and sidebar components.
+- `docs/system-rules.md` — Tag taxonomy, frontmatter schema, linking protocols.
 - `docs/visual-guideline.md` — Full design token reference.
 - `docs/custom-syntax.md` — Smart Columns and extended syntax.

--- a/claude/agents/reviewer.md
+++ b/claude/agents/reviewer.md
@@ -12,6 +12,7 @@ Audit notes for technical accuracy, style compliance, and completeness. Produce 
 
 ### 1. Structure
 - Frontmatter has required `title` field.
+- Frontmatter includes recommended `description` (≤160 chars) and `tags` fields.
 - File is at correct path: `content/<topic>/<kebab-case>.md`.
 - Headings create a scannable hierarchy (no skipped levels).
 - Content follows the appropriate template (see writer agent).

--- a/claude/agents/writer.md
+++ b/claude/agents/writer.md
@@ -23,6 +23,10 @@ Convert hands-on experiments, debugging sessions, and technical workflows into l
 ```md
 ---
 title: <Descriptive Title>
+description: <One-line summary (≤160 chars)>
+tags:
+  - <platform-tag>
+  - <topic-tag>
 ---
 
 ## Context
@@ -52,7 +56,7 @@ For debugging and incident content, enforce this structure:
 
 ## Quality Checklist
 
-- [ ] `title` in frontmatter
+- [ ] `title` in frontmatter (required); `description` and `tags` (recommended)
 - [ ] File path follows `content/<topic>/<kebab-case>.md`
 - [ ] No vague terminology — every claim has evidence
 - [ ] Mermaid only if it adds clarity (LR orientation)

--- a/claude/config.yaml
+++ b/claude/config.yaml
@@ -16,6 +16,9 @@ defaults:
   file_naming: kebab-case
   frontmatter_required:
     - title
+  frontmatter_recommended:
+    - description
+    - tags
 
 agents:
   writer:

--- a/claude/prompts/formatting.md
+++ b/claude/prompts/formatting.md
@@ -6,7 +6,19 @@ Reusable prompt fragment for Markdown style and structure conventions.
 
 - **Naming**: All files and folders use `kebab-case`.
 - **Location**: Notes go under `content/<topic-hierarchy>/`.
-- **Frontmatter**: Every `.md` file must start with YAML frontmatter containing at minimum a `title` field.
+- **Frontmatter**: Every `.md` file must start with YAML frontmatter containing at minimum a `title` field. Recommended: include `description` and `tags`.
+
+Minimal frontmatter:
+
+```yaml
+---
+title: "Note Title"
+description: "One-line summary (≤160 chars)"
+tags:
+  - platform-tag
+  - topic-tag
+---
+```
 
 ## Writing Style
 

--- a/claude/prompts/quartz.md
+++ b/claude/prompts/quartz.md
@@ -53,6 +53,8 @@ Full tag taxonomy and frontmatter rules: `docs/system-rules.md`.
 | Math | `$...$` or `$$...$$` | KaTeX rendering |
 | Mermaid | ` ```mermaid ` | See mermaid.md for rules |
 | Code blocks | ` ```lang ` | Shiki syntax highlighting |
+| YouTube embed | `![](https://youtube.com/watch?v=ID)` | Auto-converts to iframe |
+| Media embed | `![](file.mp4)` | Video, audio, PDF supported |
 
 ## Build & Verify
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Add YouTube embed syntax to writing rules, add `docs/system-rules.md` to config files reference
- **formatting.md**: Add frontmatter template example with recommended `description` and `tags` fields
- **quartz.md**: Add YouTube and media embed rows to supported syntax table
- **writer.md**: Include `description`/`tags` in output template and quality checklist
- **reviewer.md**: Add check for recommended `description` and `tags` fields
- **config.yaml**: Add `frontmatter_recommended` list (`description`, `tags`)

## Why

The prompt system was missing guidance on:
1. Recommended frontmatter fields (`description`, `tags`) — only `title` was documented
2. YouTube/media embed syntax — supported by Quartz but not mentioned anywhere
3. `docs/system-rules.md` — existed but wasn't referenced from CLAUDE.md

## Test plan

- [ ] Verify `npm run quartz -- build` passes
- [ ] Confirm no breaking changes to existing agent workflows

https://claude.ai/code/session_01L1qC33vHDbDozYN6bXu5D6