### PR TITLE
feat: 新增 Mintlify 框架評估 (closes #63)

### DIFF
--- a/content/setup-env/mintlify-evaluation.md
+++ b/content/setup-env/mintlify-evaluation.md
@@ -1,0 +1,123 @@
+---
+title: "Mintlify 文件框架評估"
+description: "Evaluation of Mintlify as documentation framework — comparison with Quartz, migration considerations, and recommendation"
+tags:
+  - research
+  - devops
+---
+
+## TL;DR
+
+- Mintlify 是一個商業化的 AI-native 文件平台，主打企業級 API 文件與知識庫
+- 與目前使用的 Quartz + GitHub Pages 方案相比，Mintlify 在搜尋和 AI 功能上有優勢，但在成本、自由度和 Obsidian 相容性上有明顯劣勢
+- **建議**：維持 Quartz 方案。Mintlify 更適合企業 API 文件場景，不適合個人數位花園
+
+## 什麼是 Mintlify
+
+- 商業化文件平台，定位為「Intelligent Knowledge Platform」
+- 提供託管式服務（hosted SaaS），不需自行部署
+- 知名客戶包括 Anthropic、Coinbase、Vercel、Zapier、Perplexity
+- 核心賣點：AI 搜尋助手、LLMs.txt / MCP 支援、API Playground、自動更新的知識庫
+- 適合場景：開發者文件、API Reference、產品文件
+
+## 技術架構
+
+| 層面 | 技術 |
+|------|------|
+| 框架 | Next.js (React) |
+| 內容格式 | MDX (Markdown + JSX components) |
+| 樣式 | Tailwind CSS |
+| 部署 | Mintlify 託管（非自建） |
+| 版本控制 | GitHub / GitLab 整合，PR 觸發 preview deploy |
+| 搜尋 | 內建 AI-powered 搜尋 + 傳統全文搜尋 |
+| 編輯器 | 內建 Web Editor + 本地 MDX 檔案 |
+
+## Quartz vs Mintlify 比較
+
+| 面向 | Quartz (目前方案) | Mintlify |
+|------|-------------------|----------|
+| **類型** | 開源靜態網站產生器 | 商業託管平台 |
+| **成本** | 免費 (GitHub Pages) | Free tier 有限；Pro $250/月 |
+| **內容格式** | Obsidian-flavored Markdown | MDX (Markdown + JSX) |
+| **部署** | GitHub Pages / 任何靜態主機 | Mintlify 託管（無法自建） |
+| **自訂主題** | 完全控制 (Preact + SCSS) | 有限自訂，依賴內建元件 |
+| **搜尋** | 客戶端全文搜尋 (FlexSearch) | AI-powered 搜尋 + 傳統搜尋 |
+| **AI 功能** | 無 | AI 助手、LLMs.txt、MCP 支援 |
+| **Obsidian 相容** | 原生支援 wikilinks、backlinks | 不支援 wikilinks，需轉換 |
+| **API 文件** | 需手動建構 | 內建 API Playground + OpenAPI 支援 |
+| **Graph View** | 內建關聯圖譜 | 無 |
+| **Vendor Lock-in** | 無 | 高（託管 + 專有元件） |
+| **離線編輯** | Obsidian 原生支援 | 僅限本地 MDX 編輯 |
+| **自訂域名** | 免費 (GitHub Pages CNAME) | 所有方案皆支援 |
+| **Preview Deploy** | 無內建 (可用 GitHub Actions) | 內建 PR preview |
+
+## 遷移考量
+
+### 內容格式轉換
+
+- Obsidian Markdown → MDX 需要大量轉換工作
+  - `[[wikilinks]]` 需改為標準 `[text](path)` 連結
+  - `:::col` Smart Columns 語法需改為 MDX 元件
+  - Mermaid 圖表需確認 MDX 環境支援度
+- 現有 frontmatter 格式大致相容，但 Mintlify 使用 `mint.json` 管理導航結構
+
+### 部署模式
+
+- Quartz：靜態檔案部署至 GitHub Pages，零成本、完全控制
+- Mintlify：託管在 Mintlify 伺服器，無法 self-host
+  - 好處：零設定、自動 SSL、CDN
+  - 風險：平台關閉 = 網站消失
+
+### 成本
+
+| 方案 | Quartz | Mintlify Hobby | Mintlify Pro |
+|------|--------|----------------|--------------|
+| 月費 | $0 | $0 (受限) | $250 |
+| AI 功能 | 無 | 無 | 250 credits + $0.25/次 |
+| 團隊成員 | 不限 | 1 | 5 |
+| 密碼保護 | 無 | 無 | 有 |
+
+### 搜尋體驗
+
+- Mintlify 的 AI 搜尋是明確優勢，可用自然語言查詢文件內容
+- Quartz 的 FlexSearch 是客戶端搜尋，對中文支援有限但堪用
+- 如需提升搜尋品質，Quartz 可整合 Algolia 或 Pagefind 等方案
+
+### Obsidian 工作流相容性
+
+- Mintlify 不支援 Obsidian wikilinks，需使用標準 Markdown 連結
+- 無法使用 Obsidian 的 Graph View 來視覺化筆記關聯
+- 失去「Obsidian 寫 → Git push → 自動部署」的順暢流程
+- MDX 語法在 Obsidian 中無法正常渲染預覽
+
+## agentskills.io 實際觀察
+
+[agentskills.io](https://agentskills.io/home) 是使用 Mintlify 建構的公開網站，展示了：
+
+- 乾淨的側邊欄導航結構
+- 深色模式支援良好
+- MDX 元件靈活度高（如 `<CardGroup>`、`<Card>` 等）
+- 頁尾標示「Built with Mintlify」
+- 適合結構化的規格文件與入門指南
+
+但也印證了 Mintlify 更適合**產品文件**而非**個人知識庫 / 數位花園**的定位。
+
+## 建議
+
+**維持現有 Quartz + GitHub Pages + Obsidian 方案。**
+
+理由：
+
+- **成本**：Quartz 完全免費，Mintlify Pro 每月 $250 對個人專案不合理
+- **工作流**：Obsidian → Git → GitHub Pages 的寫作流程已成熟，遷移 MDX 會破壞效率
+- **自由度**：Quartz 可完全客製化主題和插件，Mintlify 受限於平台規範
+- **Vendor Lock-in**：Mintlify 是託管服務，遷出成本高
+- **定位不符**：Mintlify 為企業 API 文件設計，ai-study-note 是個人學習筆記
+
+Mintlify 的優勢（AI 搜尋、API Playground）對 ai-study-note 的使用場景不是剛需。
+
+## 下一步
+
+- 如需改善搜尋體驗，評估 [Pagefind](https://pagefind.app/) 整合至 Quartz
+- 如需 AI 功能，可考慮在 Quartz 上自建 LLMs.txt 或整合 RAG 方案
+- 持續關注 Mintlify 的 Hobby tier 功能變化，未來若開放更多免費功能可重新評估


### PR DESCRIPTION
## Summary
- Add evaluation note for Mintlify documentation framework at `content/setup-env/mintlify-evaluation.md`
- Compares Mintlify (commercial hosted platform) vs current Quartz + GitHub Pages + Obsidian stack
- Recommendation: keep Quartz — Mintlify's strengths (AI search, API playground) don't justify the cost ($250/mo Pro) and workflow disruption for a personal digital garden

## Details
- Covers: tech stack, feature comparison table, migration considerations (content format, deployment, cost, search, Obsidian compatibility)
- References agentskills.io as a real-world Mintlify site
- Written in zh-tw per project conventions

Closes #63

## Test plan
- [ ] Verify note renders correctly with `npm run quartz -- build --serve`
- [ ] Check frontmatter tags align with taxonomy
- [ ] Confirm no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)