### PR TITLE
chore(cron): dispatch research/writing issue queue to agents

### DIFF
--- a/cron/dispatch-2026-04-12.md
+++ b/cron/dispatch-2026-04-12.md
@@ -1,0 +1,118 @@
+# Issue Queue Dispatch — 2026-04-12
+
+Queue audit of `wahengchang/ai-study-note` open issues, filtered for research and writing tasks, with agent delegation per `claude/config.yaml`.
+
+## Audit Summary
+
+- **Total open issues**: 7
+- **Filtered (research/writing)**: 5
+- **Already covered by open PR**: 1 (#61 → PR #73)
+- **Excluded (not research/writing)**: 2 (#63 framework migration, #67 bug fix)
+- **Actionable this cycle**: 4
+
+## Excluded Issues
+
+| Issue | Title | Reason |
+|-------|-------|--------|
+| #63 | Adopt Mintlify as new framework | Infrastructure / migration — not research or writing |
+| #67 | Fix duplicate article titles | Bug fix — already has PR #68 |
+| #61 | 研究小紅書：寶藏開源項目，自動優化專業級提示詞 | Already has open PR #73 |
+
+## Dispatch Queue
+
+Issues are ordered by number (lowest first) per `cron/git-auto.md` processing rules.
+
+---
+
+### 1. Issue #74 — Write study note on Astron Agent, Serper, Jina AI, Python node, and LLM
+
+- **Type**: Writing (content generation)
+- **Language**: zh-tw
+- **Agent**: `@writer`
+- **Reviewer**: `@reviewer`
+- **Operational requirements**:
+  - Research each tool's role (AI model vs tool vs platform vs logic node)
+  - Clarify pricing model per tool (free tier, paid, API-based)
+  - Produce a workflow-oriented note showing how components collaborate
+  - Target audience includes non-technical readers — maintain accessible language
+- **Output path**: `content/claude-code/tools-and-skills/astron-serper-jina-workflow.md`
+- **Frontmatter tags**: `guide`, `agent-architecture`, `automation`
+- **Build gate**: `npm run quartz -- build` must exit 0
+- **Definition of Done**: Article with clear title, tool-by-tool breakdown, pricing section, workflow diagram (`@diagram` if needed)
+
+---
+
+### 2. Issue #75 — Research learn note on LLM-based knowledge management with raw and wiki workflow
+
+- **Type**: Research + Writing
+- **Language**: zh-tw
+- **Agent**: `@writer` (research phase → writing phase)
+- **Reviewer**: `@reviewer`
+- **Operational requirements**:
+  - Research raw/wiki two-layer separation design (Andrej Karpathy / 林穎俊 references)
+  - Document the ingestion → structuring → querying → feedback loop
+  - Explain why IDE + Obsidian + Markdown + Git is a viable low-barrier stack
+  - Diagram the knowledge flow if it adds clarity (`@diagram`)
+- **Output path**: `content/prompt-notes/llm-knowledge-management-raw-wiki.md`
+- **Frontmatter tags**: `guide`, `automation`, `prompt-engineering`
+- **Build gate**: `npm run quartz -- build` must exit 0
+- **Definition of Done**: Study note with clear raw vs wiki distinction, flow diagram, extensibility section
+
+---
+
+### 3. Issue #76 — Research AI-powered YouTube automation workflow from n8n video
+
+- **Type**: Research (tool survey + workflow analysis)
+- **Language**: zh-tw
+- **Agent**: `@writer` (research-heavy, structured note output)
+- **Supporting agent**: `@diagram` (workflow visualization)
+- **Reviewer**: `@reviewer`
+- **Operational requirements**:
+  - Decompose the end-to-end video production pipeline (ideation → publish)
+  - Categorize tools by function: orchestration, LLM, visual, audio, rendering, publishing, storage
+  - Assess code-free vs engineering-required segments
+  - Evaluate feasibility for zh-tw content workflows
+  - Flag risks: content quality, copyright, YouTube policy, API costs
+  - Propose a minimal PoC architecture
+- **Output path**: `content/prompt-notes/ai-youtube-automation-n8n.md`
+- **Frontmatter tags**: `research`, `automation`, `n8n`
+- **Build gate**: `npm run quartz -- build` must exit 0
+- **Definition of Done**: Research note with workflow breakdown, tool classification table, PoC proposal, risk section
+
+---
+
+### 4. Issue #77 — Research terminal multiplexing workflow that boosts Claude Code productivity
+
+- **Type**: Research (tool comparison + workflow design)
+- **Language**: zh-tw
+- **Agent**: `@writer` (research → structured comparison note)
+- **Reviewer**: `@reviewer`
+- **Operational requirements**:
+  - Trace original 小紅書 content to identify the actual tool (`cmux` / `tmux` / `zellij` / other)
+  - Compare terminal multiplexers: cmux, tmux, zellij, WezTerm, screen
+  - Document Claude Code multi-pane best practices (agent, logs, git, monitoring)
+  - Produce a minimal recommended workflow setup
+- **Output path**: `content/claude-code/tools-and-skills/terminal-multiplexing-claude-code.md`
+- **Frontmatter tags**: `research`, `claude-code`, `devops`
+- **Build gate**: `npm run quartz -- build` must exit 0
+- **Definition of Done**: Research note with tool comparison table, recommended workflow, applicability/limitations section
+
+## Execution Rules
+
+Per `cron/git-auto.md`:
+
+1. **One issue per run** — process lowest-numbered actionable issue first (#74)
+2. **Branch convention**: `auto/issue-<number>` off fresh `origin/main`
+3. **Stage by explicit path only** — never `git add .` or `git add -A`
+4. **One PR per issue** — no bundling
+5. **Build verification** before every commit
+6. **Agent handoff**: `@writer` produces draft → `@reviewer` gates quality → merge
+
+## Agent Delegation Matrix
+
+| Issue | Primary Agent | Support Agent | Review Agent |
+|-------|--------------|---------------|-------------|
+| #74 | `@writer` | — | `@reviewer` |
+| #75 | `@writer` | `@diagram` | `@reviewer` |
+| #76 | `@writer` | `@diagram` | `@reviewer` |
+| #77 | `@writer` | — | `@reviewer` |


### PR DESCRIPTION
## Summary

- Audited all 7 open issues and filtered 5 research/writing tasks
- Identified 4 actionable items requiring agent execution (#74, #75, #76, #77)
- Excluded #63 (framework migration) and #67 (bug fix) as non-research/writing
- Skipped #61 — already covered by open PR #73
- Delegated each issue to the appropriate agent per `claude/config.yaml`

## Dispatch Queue

| Priority | Issue | Type | Primary Agent | Support |
|----------|-------|------|---------------|---------|
| 1 | #74 — Astron Agent, Serper, Jina AI workflow note | Writing | `@writer` | `@reviewer` |
| 2 | #75 — LLM knowledge management (raw/wiki) | Research+Writing | `@writer` | `@diagram`, `@reviewer` |
| 3 | #76 — AI YouTube automation (n8n) | Research | `@writer` | `@diagram`, `@reviewer` |
| 4 | #77 — Terminal multiplexing for Claude Code | Research | `@writer` | `@reviewer` |

## Execution Rules (per `cron/git-auto.md`)

- One issue per run, lowest number first
- Branch `auto/issue-<N>` off fresh `origin/main`
- Stage by explicit path only
- `npm run quartz -- build` must exit 0 before commit
- `@writer` drafts → `@reviewer` gates → merge

## Test plan

- [x] Dispatch manifest at `cron/dispatch-2026-04-12.md` is well-formed
- [x] No `.automation/` files staged
- [x] Branch is clean off `origin/main`
- [ ] Each dispatched issue can be picked up by `git-auto` workflow

https://claude.ai/code/session_01ExAZEgrG5YwfS14m3a7XDx