### PR TITLE
feat: dispatch plan for research/writing issue queue

### DIFF
--- a/cron/dispatch-2026-04-12.md
+++ b/cron/dispatch-2026-04-12.md
@@ -1,0 +1,114 @@
+# Dispatch Plan — 2026-04-12
+
+> Audit of open issue queue, filtered for research and writing tasks, with agent delegation assignments. This plan initiates the execution workflow defined in [`git-auto.md`](./git-auto.md).
+
+## Audit Summary
+
+| Metric | Value |
+|--------|-------|
+| Total open issues | 7 |
+| Filtered (research/writing) | 5 |
+| Excluded (non-research) | 2 |
+| Assigned agent | `@writer` (all 5) |
+
+## Dispatched Issues
+
+Issues are ordered by priority (lowest issue number first, per `git-auto.md` §4).
+
+### #61 — Research open-source prompt optimization project
+
+| Field | Value |
+|-------|-------|
+| **Agent** | `@writer` |
+| **Operation** | Research — identify project, summarize features, assess applicability |
+| **Target** | `content/prompt-notes/prompt-auto-optimization-research.md` |
+| **Tags** | `research`, `prompt-engineering` |
+| **Branch** | `auto/issue-61` |
+
+**Requirements**: Identify the open-source project referenced in the Xiaohongshu post about automatic professional prompt optimization. Produce a research summary covering: project identity and repo link, core functionality (TL;DR in 3-5 lines), at least 3 reusable insights, and a conclusion on whether it fits `ai-study-note`.
+
+---
+
+### #74 — Write study note on AI workflow components
+
+| Field | Value |
+|-------|-------|
+| **Agent** | `@writer` |
+| **Operation** | Writing — draft study note from existing user-provided material |
+| **Target** | `content/prompt-notes/ai-workflow-tools-study.md` |
+| **Tags** | `research`, `automation`, `agent-architecture` |
+| **Branch** | `auto/issue-74` |
+
+**Requirements**: Explain the role of each component in an AI workflow: Astron Agent (orchestration), Serper.dev (search API), Jina AI (reader/embeddings), Python node (logic glue), LLM (generation). Clarify pricing tiers. Emphasize these are distinct workflow components, not a single AI tool. Write for non-technical readers with precise terminology.
+
+---
+
+### #75 — Research LLM-based knowledge management (raw/wiki)
+
+| Field | Value |
+|-------|-------|
+| **Agent** | `@writer` |
+| **Operation** | Research — synthesize knowledge management pattern into study note |
+| **Target** | `content/prompt-notes/llm-knowledge-management-raw-wiki.md` |
+| **Tags** | `research`, `agent-architecture` |
+| **Branch** | `auto/issue-75` |
+
+**Requirements**: Document the raw/wiki two-layer pattern inspired by Andrej Karpathy and 林穎俊. Cover: immutable raw layer (original material never edited), evolving wiki layer (AI-structured summaries), AI-driven classification and linking, query-based knowledge reinforcement loop. Include a practical implementation sketch using IDE + Obsidian + Markdown + Git.
+
+---
+
+### #76 — Research AI-powered YouTube automation (n8n)
+
+| Field | Value |
+|-------|-------|
+| **Agent** | `@writer` |
+| **Operation** | Research — decompose video workflow and catalog tools |
+| **Target** | `content/prompt-notes/n8n-youtube-automation-research.md` |
+| **Tags** | `research`, `automation`, `n8n` |
+| **Branch** | `auto/issue-76` |
+
+**Requirements**: Decompose the end-to-end AI YouTube video generation workflow from the referenced n8n video. Map each pipeline stage to specific tools across 7 categories: orchestration, LLM/script, visual generation, audio/voice, video assembly, publishing, and storage/notification. Include cost structure analysis, risk assessment (copyright, YouTube policy, content quality), and a minimum-viable PoC architecture.
+
+---
+
+### #77 — Research terminal multiplexing for Claude Code
+
+| Field | Value |
+|-------|-------|
+| **Agent** | `@writer` |
+| **Operation** | Research — investigate and compare terminal multiplexers for AI coding |
+| **Target** | `content/claude-code/terminal-multiplexing-workflow.md` |
+| **Tags** | `research`, `claude-code`, `tmux` |
+| **Branch** | `auto/issue-77` |
+
+**Requirements**: Investigate cmux and related terminal multiplexers (tmux, zellij, WezTerm) for Claude Code productivity. Confirm what tool the original Xiaohongshu post refers to. Compare at least 3 tools. Document the multi-pane workflow pattern (agent pane + logs pane + git/test pane + monitor pane). Propose a minimum viable setup with clear applicability and limitations.
+
+---
+
+## Excluded Issues
+
+| # | Title | Reason |
+|---|-------|--------|
+| 67 | Fix duplicate article titles | Bug fix — delegate to `@content-ops`, not research/writing |
+| 63 | Adopt Mintlify as new framework | Infrastructure evaluation — out of current dispatch scope |
+
+## Execution Protocol
+
+Per [`git-auto.md`](./git-auto.md):
+
+1. Process one issue per run, lowest number first
+2. Branch fresh from `origin/main` as `auto/issue-<N>`
+3. `@writer` agent produces the note following `claude/agents/writer.md` output format
+4. `@reviewer` agent audits the draft before PR creation
+5. Validate with `npm run quartz -- build`
+6. Stage files by explicit path only — never `git add .`
+7. Create one PR per issue; record status in `.automation/issues.json`
+
+## Agent Capability Matrix
+
+| Agent | Role in this dispatch |
+|-------|----------------------|
+| `@writer` | Primary — authors all 5 research/study notes |
+| `@reviewer` | Secondary — audits each draft before PR |
+| `@content-ops` | Standby — resolves placement ambiguity if decision tree hits STOP |
+| `@diagram` | On-call — generates Mermaid diagrams if writer determines visualization adds clarity |


### PR DESCRIPTION
## Summary

- Audited all 7 open issues and filtered **5 research/writing tasks** (#61, #74, #75, #76, #77)
- Excluded 2 non-research issues: #67 (bug fix → `@content-ops`) and #63 (infrastructure evaluation)
- Delegated all 5 filtered issues to the `@writer` agent based on skill-set analysis
- Created `cron/dispatch-2026-04-12.md` as the execution initiation document per `cron/git-auto.md` workflow

## Dispatch Overview

| Priority | Issue | Task | Agent | Target |
|----------|-------|------|-------|--------|
| 1 | #61 | Research prompt auto-optimization OSS project | `@writer` | `content/prompt-notes/` |
| 2 | #74 | Write study note on AI workflow components | `@writer` | `content/prompt-notes/` |
| 3 | #75 | Research LLM knowledge management (raw/wiki) | `@writer` | `content/prompt-notes/` |
| 4 | #76 | Research AI YouTube automation (n8n) | `@writer` | `content/prompt-notes/` |
| 5 | #77 | Research terminal multiplexing for Claude Code | `@writer` | `content/claude-code/` |

## Agent Capability Matrix

| Agent | Role |
|-------|------|
| `@writer` | Primary — authors all 5 research/study notes |
| `@reviewer` | Secondary — audits each draft before PR |
| `@content-ops` | Standby — resolves placement ambiguity |
| `@diagram` | On-call — Mermaid diagrams where visualization adds clarity |

## Execution Protocol

Per `cron/git-auto.md`: one issue per run, lowest number first, branch as `auto/issue-<N>` from `origin/main`, validate with `npm run quartz -- build`, stage by explicit path only.

## Test plan

- [x] `npm run quartz -- build` passes (65 files, 0 errors)
- [x] `.automation/issues.json` initialized locally (gitignored, not committed)
- [x] No `.automation/` paths in staged diff
- [ ] Verify dispatch plan is readable and accurate against issue queue

https://claude.ai/code/session_01BeiHdegazWWDXiUPUHj9ur