### PR TITLE
chore(cron): dispatch 5 research/writing issues to agent pipeline

### DIFF
--- a/cron/dispatch-2026-04-12.md
+++ b/cron/dispatch-2026-04-12.md
@@ -1,0 +1,173 @@
+# Issue Queue Dispatch — 2026-04-12
+
+> Execution brief generated per `cron/git-auto.md` workflow.
+> Language: zh-TW (per git-auto.md team convention)
+
+## Triage Summary
+
+| Metric | Count |
+|--------|-------|
+| Total open issues | 7 |
+| Filtered (research & writing) | 5 |
+| Excluded (infra / bug fix) | 2 |
+| Already has open PR branch | 1 (#61 → `auto/issue-61`) |
+
+---
+
+## Excluded Issues (out of scope)
+
+| Issue | Title | Reason |
+|-------|-------|--------|
+| #63 | Adopt Mintlify as new framework | Infrastructure migration — not research/writing |
+| #67 | Fix duplicate article titles | Bug fix / template logic — not research/writing |
+
+---
+
+## Dispatch Queue
+
+Issues are ordered by number (lowest first), per `git-auto.md` §4.
+
+### 1. Issue #61 — Research: 自動優化專業級提示詞開源專案
+
+| Field | Value |
+|-------|-------|
+| **Type** | Research |
+| **Agent** | `@writer` (Architect) |
+| **Branch** | `auto/issue-61` (exists — check PR status before re-work) |
+| **Output path** | `content/prompt-notes/prompt-optimization-oss-research.md` |
+| **Requires diagram** | No |
+
+**Operational requirements:**
+- Web research to identify the open-source project referenced in the 小紅書 post
+- TL;DR (3–5 lines), core features, applicable scenarios
+- Conclusion on whether it fits `ai-study-note` scope
+- DoD: confirm source project, research summary, 3+ reusable takeaways, inclusion verdict
+
+**Execution steps:**
+1. `@writer` researches and drafts note (Architect objective)
+2. `@reviewer` audits for accuracy + style
+3. Validate build: `npm run quartz -- build`
+
+---
+
+### 2. Issue #74 — Write: Astron Agent / Serper / Jina AI / Python Node / LLM
+
+| Field | Value |
+|-------|-------|
+| **Type** | Writing |
+| **Agent** | `@writer` (Architect) → `@diagram` (Generate) |
+| **Branch** | `auto/issue-74` |
+| **Output path** | `content/ai-tools/ai-workflow-components-astron-serper-jina.md` |
+| **Requires diagram** | Yes — workflow component diagram (flowchart LR) |
+
+**Operational requirements:**
+- Explain each tool's role: AI model vs. tool vs. platform vs. logic node
+- Clarify pricing model per component (free tier / paid)
+- Official links for each tool
+- Workflow integration diagram showing how components connect
+- Audience: accessible to non-technical readers
+
+**Execution steps:**
+1. `@writer` drafts the study note (Architect objective, 白話 tone per issue)
+2. `@diagram` generates workflow component flowchart (`flowchart LR`)
+3. `@reviewer` audits accuracy (especially pricing claims) + style
+4. Validate build: `npm run quartz -- build`
+
+---
+
+### 3. Issue #75 — Research + Write: LLM-based Knowledge Management (raw/wiki)
+
+| Field | Value |
+|-------|-------|
+| **Type** | Research + Writing |
+| **Agent** | `@writer` (Architect) → `@diagram` (Generate) |
+| **Branch** | `auto/issue-75` |
+| **Output path** | `content/ai-tools/llm-knowledge-management-raw-wiki.md` |
+| **Requires diagram** | Yes — raw/wiki data flow (stateDiagram-v2 or flowchart LR) |
+
+**Operational requirements:**
+- Core concept: raw layer (immutable source) vs. wiki layer (evolving knowledge)
+- Reference: Andrej Karpathy + 林穎俊 approaches
+- Implementation stack: IDE + Obsidian + Markdown + Git
+- Feedback loop: query → new insights → write-back to wiki
+- Explain why this suits personal knowledge management
+
+**Execution steps:**
+1. `@writer` researches references and drafts learn note (Architect objective)
+2. `@diagram` generates raw→wiki data flow diagram
+3. `@reviewer` audits completeness (all DoD items) + style
+4. Validate build: `npm run quartz -- build`
+
+---
+
+### 4. Issue #76 — Research: AI-powered YouTube Automation (n8n)
+
+| Field | Value |
+|-------|-------|
+| **Type** | Research |
+| **Agent** | `@writer` (Architect) → `@diagram` (Generate) |
+| **Branch** | `auto/issue-76` |
+| **Output path** | `content/ai-tools/ai-youtube-automation-n8n-workflow.md` |
+| **Requires diagram** | Yes — end-to-end workflow pipeline (flowchart LR) |
+
+**Operational requirements:**
+- Decompose the full video production pipeline (7 stages per issue outline)
+- Tool inventory across 7 categories (orchestration, LLM, visual, audio, rendering, publishing, storage)
+- Assess no-code vs. engineering-required segments
+- API cost structure and dependencies
+- Risk analysis: content quality, copyright, YouTube policy
+- Propose minimum viable PoC architecture
+
+**Execution steps:**
+1. `@writer` researches YouTube video content and drafts study note (Architect objective)
+2. `@diagram` generates end-to-end pipeline flowchart + PoC architecture diagram
+3. `@reviewer` audits tool claims, cost info, and risk assessment
+4. Validate build: `npm run quartz -- build`
+
+---
+
+### 5. Issue #77 — Research: Terminal Multiplexing for Claude Code Productivity
+
+| Field | Value |
+|-------|-------|
+| **Type** | Research |
+| **Agent** | `@writer` (Architect) |
+| **Branch** | `auto/issue-77` |
+| **Output path** | `content/claude-code/terminal-multiplexing-claude-code-workflow.md` |
+| **Requires diagram** | Optional — pane layout diagram if it adds clarity |
+
+**Operational requirements:**
+- Identify actual tool referenced in 小紅書 post (`cmux` / `tmux` / other)
+- Compare terminal multiplexers: cmux, tmux, zellij, WezTerm, Warp
+- Claude Code multi-pane best practices (agent / logs / git / monitor)
+- Propose a minimal practical workflow
+- DoD: tool identity confirmed, 3+ comparisons, 1 recommended workflow
+
+**Execution steps:**
+1. `@writer` researches and drafts study note (Architect objective)
+2. `@reviewer` audits tool comparisons and workflow recommendation
+3. Validate build: `npm run quartz -- build`
+
+---
+
+## Execution Protocol
+
+Per `cron/git-auto.md`:
+
+1. Process **one issue per run**, lowest number first
+2. Skip issues with `in_progress` status or existing open PR
+3. Branch from `origin/main`: `git fetch origin && git checkout -B auto/issue-<N> origin/main`
+4. Stage files by **explicit path only** — never `git add .` or `git add -A`
+5. Verify staged diff before commit: `git diff --cached --stat`
+6. Never stage `.automation/` files
+7. One PR per issue, one issue per PR
+8. Mark tracker status: `in_progress` → `pr_open` (success) or `failed` (validation failure)
+
+## Agent Capability Matrix
+
+| Agent | Issues Assigned | Role |
+|-------|----------------|------|
+| `@writer` | #61, #74, #75, #76, #77 | Primary author — research + draft |
+| `@diagram` | #74, #75, #76 | Workflow/architecture diagrams |
+| `@reviewer` | #61, #74, #75, #76, #77 | QA gate before PR merge |
+| `@content-ops` | — | Post-merge taxonomy alignment (if needed) |


### PR DESCRIPTION
## Summary

- Audited the full open issue queue (7 issues) and filtered **5 research/writing tasks** for execution
- Mapped each issue to the appropriate agent(s) from the modular prompt system (`claude/agents/`)
- Created `cron/dispatch-2026-04-12.md` as the execution brief, following `cron/git-auto.md` protocol

## Dispatch Queue

| Priority | Issue | Type | Primary Agent | Diagram |
|----------|-------|------|---------------|---------|
| 1 | #61 — 自動優化提示詞開源專案研究 | Research | `@writer` | — |
| 2 | #74 — Astron Agent / Serper / Jina AI study note | Writing | `@writer` | `@diagram` |
| 3 | #75 — LLM knowledge management (raw/wiki) | Research + Writing | `@writer` | `@diagram` |
| 4 | #76 — AI YouTube automation (n8n) | Research | `@writer` | `@diagram` |
| 5 | #77 — Terminal multiplexing for Claude Code | Research | `@writer` | optional |

**Excluded:** #63 (infra migration), #67 (bug fix) — not research/writing scope.

All issues pass through `@reviewer` QA gate before merge.

## Execution Protocol

Per `cron/git-auto.md`: one issue per run, branch from `origin/main`, explicit file staging only, one PR per issue.

## Test plan

- [ ] Verify `cron/dispatch-2026-04-12.md` renders correctly on the Quartz site
- [ ] Confirm no `.automation/` files are included in the diff
- [ ] Validate each issue link resolves to an open issue
- [ ] First execution run picks issue #61 (lowest number)

https://claude.ai/code/session_015n4u9q135KPsBmaKTvpirE