### PR TITLE
chore(cron): dispatch research/writing issue queue to agents

### DIFF
--- a/cron/dispatch-2026-04-12.md
+++ b/cron/dispatch-2026-04-12.md
@@ -1,0 +1,106 @@
+# Issue Queue Dispatch — 2026-04-12
+
+Initiates the execution workflow defined in [`cron/git-auto.md`](./git-auto.md).
+Source of truth for open issues: GitHub repo `wahengchang/ai-study-note`.
+Agent registry: [`claude/agents/`](../claude/agents/).
+
+## 1. Audit summary
+
+| Metric | Value |
+|---|---|
+| Open issues scanned | 7 |
+| Research / writing candidates | 5 |
+| Non-research (out of scope) | 2 (#63 framework migration, #67 layout bug) |
+| Lowest-number actionable | #61 |
+
+## 2. Filtered queue — research & writing only
+
+Ordered lowest-number-first, matching the `git-auto.md` pick rule
+("Pick one open issue to work on per run (lowest number first)").
+
+| # | Title | Type | Target folder | Agent | Priority |
+|---|---|---|---|---|---|
+| 61 | 小紅書：寶藏開源項目，自動優化專業級提示詞 | Research | `content/prompt-notes/` | `@writer` | first |
+| 74 | Astron Agent / Serper / Jina / Python node / LLM study note | Writing | `content/claude-code/` or new `content/ai-workflow/` | `@writer` → `@content-ops` | next |
+| 75 | LLM-based knowledge management (raw / wiki workflow) | Research + Writing | `content/claude-code/` | `@writer` | next |
+| 76 | n8n AI YouTube automation workflow | Research | `content/` (new topic: `ai-workflow/`) | `@writer` → `@content-ops` | next |
+| 77 | Terminal multiplexing workflow for Claude Code (cmux / tmux) | Research | `content/claude-code/` | `@writer` | next |
+
+Out of scope for this queue:
+- **#63** — Mintlify framework migration. Infrastructure decision, not a note.
+- **#67** — Duplicate H1 rendering bug. Layout/template fix, not research.
+
+## 3. Operational requirements per issue
+
+### #61 — 自動優化提示詞 開源專案
+- **Input**: Xiaohongshu link (`http://xhslink.com/o/7iAalKtM6SX`).
+- **Discovery cost**: medium — original post lists no repo name; need cross-search
+  for the project by description ("自動優化專業級提示詞", open-source).
+- **Deliverable**: research summary with repo URL, TL;DR (3–5 lines),
+  core features, ≥3 reusable takeaways, fit-for-inclusion verdict.
+- **DoD checklist from issue**: 4 items, all bound to the research note file.
+- **Risk**: original link may be dead; keep `> [!warning]` on unverifiable claims
+  per `writer.md` §Behavior §1.
+- **Agent**: `@writer` (research note; no diagrams expected unless a system
+  diagram genuinely aids the summary → then escalate to `@diagram`).
+
+### #74 — Astron Agent / Serper / Jina / Python node / LLM
+- **Input**: user-supplied Telegram summary (already drafted, one-liners + pricing).
+- **Discovery cost**: low — user has pre-researched each tool.
+- **Deliverable**: publishable note clarifying each component's role,
+  pricing model, and position in one AI workflow (not interchangeable AI tools).
+- **Audience**: non-technical readers; keep a plain-language pass.
+- **Agent**: `@writer` for draft; hand to `@content-ops` to place the file
+  (candidate folder: may need new `content/ai-workflow/` — check
+  `docs/content-taxonomy.md` before creating).
+
+### #75 — raw / wiki LLM knowledge management
+- **Input**: user's own description + Karpathy + 林穎俊老師 reference points.
+- **Discovery cost**: low-medium — source material provided; needs synthesis.
+- **Deliverable**: learn-note outline or draft explaining the raw/wiki split,
+  AI-assisted curation loop, and why it suits personal knowledge management.
+- **Related prior art on repo**: `bc7dd17 feat: 新增 Karpathy LLM-maintained wiki 研究筆記 (closes #65)` — must read existing note first and position this as a complementary piece, not a duplicate.
+- **Agent**: `@writer`; if overlap with #65 note is high, mark `clarification_needed` per `git-auto.md` step 4.
+
+### #76 — n8n AI YouTube automation
+- **Input**: YouTube video (`watch?v=5Htbfh_LYSE`), Japanese.
+- **Discovery cost**: high — video is long-form; must extract the workflow
+  without transcription tooling if unavailable. List assumptions explicitly.
+- **Deliverable**: end-to-end workflow breakdown, tool-by-category inventory,
+  PoC architecture sketch, risk/compliance section (copyright, YouTube policy).
+- **Breadth**: touches ≥15 tools across 6 categories — risk of shallow coverage.
+  Scope the note to orchestration layer + one category deep-dive; reference
+  others without claims we cannot verify.
+- **Agent**: `@writer` for the note; `@content-ops` to classify (likely new
+  `content/ai-workflow/` folder — needs taxonomy approval first).
+
+### #77 — cmux / terminal multiplexing for Claude Code
+- **Input**: Xiaohongshu post (`http://xhslink.com/o/AAbGLpO7BY4`).
+- **Discovery cost**: medium — `cmux` is ambiguous (the term is reused by several
+  projects). Verify which tool the post means before comparison tables.
+- **Deliverable**: research note + comparison table (cmux / tmux / zellij /
+  WezTerm mux / others) + one minimum-viable Claude Code workflow recommendation.
+- **Agent**: `@writer`; comparison table fits existing `content/claude-code/`
+  formatting — no `@content-ops` handoff needed.
+
+## 4. Dispatch rules honored from `cron/git-auto.md`
+
+- Invariants respected: no `.automation/` staged; `.gitignore` already excludes it.
+- Branch discipline: this dispatch commit targets the session's designated
+  development branch (`claude/gracious-hawking-TPqXs`). Per-issue execution runs
+  will still branch `auto/issue-<n>` fresh from `origin/main` as the cron spec
+  requires.
+- "One issue per run": actual issue work is **not** bundled here. This file is
+  the plan only. Each issue PR will be opened in its own run.
+- "Skip issues with an open PR": none of #61, #74, #75, #76, #77 currently have
+  an issue-closing PR open (checked against the open PR list — existing open PRs
+  are prior dispatch plans, not issue resolutions).
+
+## 5. Next run — handoff
+
+- Pick #61 first. Branch: `auto/issue-61` from `origin/main`.
+- Mark #61 `in_progress` in the tracker **before** starting content work.
+- Target path: `content/prompt-notes/<kebab-case>.md` (exact filename decided
+  after the project under research is identified).
+- Validation gate: `npm run quartz -- build` must exit 0 before PR open.
+- On success: mark `pr_open`. On validation failure: mark `failed`, stop.


### PR DESCRIPTION
## Summary
- Filters 5 research/writing issues from the open queue: #61, #74, #75, #76, #77.
- Documents operational requirements per issue (input source, discovery cost, deliverable, risks).
- Delegates each to the appropriate agent from `claude/agents/`: `@writer` primary, with `@content-ops` / `@diagram` handoffs where taxonomy placement or visualization warrants it.
- Honors `cron/git-auto.md` invariants: plan-only (no issue work bundled), no `.automation/` staged, per-issue runs will still branch `auto/issue-<n>` fresh from `origin/main`.

## Filtered queue
| # | Agent | Rationale |
|---|---|---|
| 61 | `@writer` | Research summary of prompt-optimization OSS project |
| 74 | `@writer` → `@content-ops` | Workflow component study note; new taxonomy folder likely |
| 75 | `@writer` | raw/wiki LLM knowledge management learn note |
| 76 | `@writer` → `@content-ops` | n8n AI YouTube automation breakdown; broad scope requires classification |
| 77 | `@writer` | cmux / terminal multiplexing comparison for Claude Code |

Out of scope (not research/writing): #63 (Mintlify migration), #67 (duplicate H1 bug).

## Next run
Lowest-number-first rule selects **#61**. Branch `auto/issue-61` off fresh `origin/main`, mark `in_progress` in tracker before content work begins.

## Test plan
- [x] No `.automation/` paths staged (verified via `git diff --cached --stat`).
- [x] One file added, under `cron/`, matches plan-only scope.
- [ ] No build step required — dispatch plan is documentation only, does not touch `content/` or Quartz config.

https://claude.ai/code/session_01RcQFp8Qk8WrFvDCLuHuEGM