### PR TITLE
chore(cron): dispatch research/writing issue queue to agents

### DIFF
--- a/cron/dispatch-2026-04-13.md
+++ b/cron/dispatch-2026-04-13.md
@@ -1,0 +1,59 @@
+---
+title: Research & Writing Issue Dispatch — 2026-04-13
+---
+
+## Audit Scope
+
+Repository: `wahengchang/ai-study-note`
+Open issues surveyed: **7** (#61, #63, #67, #74, #75, #76, #77)
+Execution workflow: [`cron/git-auto.md`](./git-auto.md)
+
+## Filter — Research & Writing Lane
+
+| # | Title (short) | Lane |
+|---|---|---|
+| 61 | 小紅書 prompt-optimizer research | Research |
+| 74 | Astron Agent / Serper / Jina / Python node / LLM note | Writing |
+| 75 | LLM-based knowledge management (raw + wiki) | Research + Writing |
+| 76 | n8n YouTube automation workflow research | Research |
+| 77 | cmux + Claude Code terminal multiplexing research | Research |
+
+**Excluded (out of lane):**
+
+- **#63** — Mintlify framework adoption → architecture/platform decision, not a note. Defer until product call.
+- **#67** — Duplicate H1 on rendered pages → layout/content bug, belongs in engineering lane.
+
+## Operational Requirements → Agent Mapping
+
+| Issue | Core deliverable | Primary agent | Support agents | Content path |
+|---|---|---|---|---|
+| #61 | Identify upstream repo from 小紅書 post; produce research summary + 3 reusable takeaways | `@writer` | `@reviewer` (accuracy on repo claims) | `content/prompt-notes/` |
+| #74 | Study note distinguishing AI model vs. tool vs. platform vs. code-node; pricing posture per component | `@writer` | `@diagram` (component role diagram), `@reviewer` | `content/prompt-notes/` or `content/claude-code/` — `@content-ops` to confirm placement |
+| #75 | Learn note on raw/wiki two-layer knowledge system; framing + why-it-works | `@writer` | `@diagram` (raw → wiki → query flow, LR), `@reviewer` | `content/claude-code/` (workflow-oriented) |
+| #76 | End-to-end workflow map of n8n YouTube agent video + tool inventory + PoC sketch | `@writer` | `@diagram` (pipeline LR), `@reviewer` | `content/prompt-notes/` — `@content-ops` to confirm |
+| #77 | cmux identity confirmation; comparison vs tmux/zellij/WezTerm; Claude Code pane workflow | `@writer` | `@reviewer` | `content/claude-code/` |
+
+## Execution Order (per git-auto.md)
+
+> Invariant: **one issue per branch, one branch per PR, lowest number first.**
+
+1. **#61** — next to execute
+2. #74
+3. #75
+4. #76
+5. #77
+
+Each run will:
+
+- Branch fresh from `origin/main` as `auto/issue-<n>`
+- Draft the note with `@writer` (composing the listed support agents)
+- Validate `npm run quartz -- build`
+- Stage by explicit path (no `.automation/`, no `git add -A`)
+- Push and open one PR per issue
+
+## Notes for Writer Agent
+
+- All five issues have substantial user-supplied context in the issue body — treat that as primary source material.
+- Mermaid diagrams only when they clarify comparative or sequential structure (LR only).
+- Frontmatter `title` is required; filenames kebab-case.
+- For #61 and #77, first deliverable is **source verification** (confirm the actual project/tool). Do not draft the note until upstream identity is pinned down.


### PR DESCRIPTION
## Summary

Audit the 7 open issues on `wahengchang/ai-study-note`, filter into the research & writing lane, and produce an agent-delegation manifest that initiates the `cron/git-auto.md` execution workflow.

## Filter result

**In-lane (5):** #61, #74, #75, #76, #77 — research and/or writing deliverables.
**Out-of-lane (2):** #63 (framework migration), #67 (layout/content bug).

## Agent mapping (primary → support)

| Issue | Primary | Support |
|---|---|---|
| #61 | `@writer` | `@reviewer` |
| #74 | `@writer` | `@diagram`, `@reviewer`, `@content-ops` |
| #75 | `@writer` | `@diagram`, `@reviewer` |
| #76 | `@writer` | `@diagram`, `@reviewer`, `@content-ops` |
| #77 | `@writer` | `@reviewer` |

## Execution order (git-auto.md invariant — lowest number first)

1. **#61** → next
2. #74
3. #75
4. #76
5. #77

Per `cron/git-auto.md`: one issue per branch, one branch per PR, branch fresh from `origin/main`, stage by explicit path. Each run produces one note under `content/…` after `@writer` drafting, `@diagram` where a LR flow aids clarity, and `@reviewer` sign-off.

## Test plan

- [x] Dispatch manifest lives under `cron/dispatch-2026-04-13.md`
- [x] No `.automation/` or unrelated paths staged
- [x] Execution queue respects `git-auto.md` ordering
- [ ] Follow-up: first executor run picks up #61 on a fresh `auto/issue-61` branch