### PR TITLE
chore(cron): dispatch research/writing issue queue to agents (2026-04-13)

### DIFF
--- a/cron/dispatch-2026-04-13.md
+++ b/cron/dispatch-2026-04-13.md
@@ -1,0 +1,91 @@
+# Dispatch Plan — Research & Writing Queue (2026-04-13)
+
+Triaged per [`cron/git-auto.md`](./git-auto.md). The git-auto runner processes **one issue per run, lowest number first**. This manifest records the filtered queue, operational requirements, and agent delegation so successive runs have a deterministic plan.
+
+## Filter Criteria
+
+- Source: `wahengchang/ai-study-note` open issues on 2026-04-13.
+- Include: issues whose primary deliverable is a research note or published study note under `content/`.
+- Exclude: platform migration (#63), site/layout bug fixes (#67), and any issue without a writing deliverable.
+
+## Filtered Queue (execution order)
+
+| Order | Issue | Title (short) | Type | Primary Agent | Support | Deliverable |
+|-------|-------|---------------|------|---------------|---------|-------------|
+| 1 | #61 | 小紅書 auto prompt optimizer OSS | Research | `@writer` | `@reviewer` | Research summary note + TL;DR |
+| 2 | #74 | Astron Agent / Serper / Jina / Python / LLM | Writing | `@writer` | `@reviewer` | Study note: workflow 零件分工 |
+| 3 | #75 | LLM raw/wiki knowledge management | Research → Writing | `@writer` | `@diagram`, `@reviewer` | Learn note with raw↔wiki flow diagram |
+| 4 | #76 | n8n AI-powered YouTube automation | Research | `@writer` | `@diagram`, `@reviewer` | Workflow note + tool taxonomy + PoC sketch |
+| 5 | #77 | cmux / terminal multiplexing for Claude Code | Research | `@writer` | `@diagram`, `@reviewer` | Research note + tool comparison + minimal workflow |
+
+Excluded this run: #63 (framework migration planning — not a research/writing note), #67 (layout/bug fix — belongs to `@content-ops`).
+
+## Operational Requirements per Issue
+
+### #61 — 小紅書 寶藏開源提示詞優化專案
+- **Skill set:** source verification, OSS repo reading, concise research summary.
+- **Inputs:** `http://xhslink.com/o/7iAalKtM6SX` (may require follow-link to reach the real repo), existing discussion comment (1).
+- **Risks:** original link resolves to a short-form post; candidate project is ambiguous. Writer must confirm the real repo before writing.
+- **Acceptance:** repo identity confirmed, 3–5 line TL;DR, 3+ reusable takeaways, inclusion verdict.
+- **Agent:** `@writer` (Principal-Engineer tone, evidence-based). Hand to `@reviewer` once drafted.
+- **Target path:** `content/research-notes/<kebab>.md` (final folder decided via `@content-ops` taxonomy check).
+
+### #74 — Astron Agent / Serper / Jina / Python node / LLM
+- **Skill set:** workflow decomposition, pricing literacy, non-technical-friendly writing.
+- **Inputs:** user-provided Telegram digest (already structured).
+- **Risks:** mixing "AI tool" vs "workflow component" framing — the note must keep these distinct.
+- **Acceptance:** explicit title, published-ready draft, per-tool role + pricing posture + official link, summary reframing the diagram as workflow parts.
+- **Agent:** `@writer`. `@reviewer` for style/accuracy.
+- **Target path:** `content/ai-workflow-notes/<kebab>.md` pending taxonomy check.
+
+### #75 — LLM-based knowledge management (raw / wiki)
+- **Skill set:** concept distillation, reference synthesis (Karpathy, 林穎俊老師), authoring outline.
+- **Inputs:** user-provided zh-TW narrative, FB share reference.
+- **Risks:** scope creep into tool comparison or production architecture — explicitly out of scope.
+- **Acceptance:** outline/draft, clear raw vs wiki separation, value prop, extension hooks (query → write-back loop).
+- **Agent:** `@writer`; `@diagram` for the raw → wiki → query loop (LR orientation); `@reviewer` before publish.
+- **Target path:** `content/learn-notes/<kebab>.md` pending taxonomy check.
+
+### #76 — n8n AI-powered YouTube automation workflow
+- **Skill set:** end-to-end workflow mapping, tool taxonomy, cost/risk analysis.
+- **Inputs:** YouTube video (`5Htbfh_LYSE`), tool list already enumerated in the issue.
+- **Risks:** large tool surface; writer must resist listing everything and instead group by workflow stage. YouTube policy / copyright / duplicate-content flags are mandatory.
+- **Acceptance:** full workflow decomposition, categorized tool list, minimum-viable PoC sketch, explicit risk section.
+- **Agent:** `@writer`; `@diagram` for the stage → tool flow (LR); `@reviewer` before publish.
+- **Target path:** `content/research-notes/<kebab>.md` pending taxonomy check.
+
+### #77 — cmux / terminal multiplexing for Claude Code
+- **Skill set:** tool identity verification (xhs link), comparative tooling analysis, practical workflow design.
+- **Inputs:** `http://xhslink.com/o/AAbGLpO7BY4`. Tool identity ambiguous — could be a new `cmux`, or a misread of an existing multiplexer.
+- **Risks:** guessing the tool. Writer must verify before writing; otherwise file as `clarification_needed`.
+- **Acceptance:** confirmed tool identity, ≥3 comparable workflow alternatives (tmux / zellij / WezTerm / etc.), one concrete Claude Code workflow, scope & limits.
+- **Agent:** `@writer`; `@diagram` for pane-layout workflow (LR); `@reviewer` before publish.
+- **Target path:** `content/research-notes/<kebab>.md` pending taxonomy check.
+
+## Agent Responsibilities Map
+
+| Agent | Trigger | Scope in this queue |
+|-------|---------|---------------------|
+| `@writer` | Primary author on all 5 issues | Draft lean, evidence-based Quartz notes; flag assumptions with `> [!warning]` |
+| `@diagram` | Invoked from #75, #76, #77 | Mermaid LR flow: raw↔wiki loop, YouTube pipeline stages, terminal pane layout |
+| `@reviewer` | Final gate on every issue | Enforce frontmatter `title`, kebab-case path, LR-only Mermaid, no fluff, build passes |
+| `@content-ops` | Post-draft placement only | Resolve final folder & tags via `docs/content-taxonomy.md`; update `index.md` and wikilinks |
+
+## Execution Workflow (per `cron/git-auto.md`)
+
+Next run consumes `#61`:
+
+1. Preflight: `git fetch origin`, clean tree, `.automation/` never staged.
+2. Pick `#61` (lowest open research/writing issue).
+3. Mark `in_progress` in `.automation/issues.json` (local state only).
+4. `git checkout -B auto/issue-61 origin/main`.
+5. `@writer` drafts the research summary; `@diagram` skipped (no diagram warranted); `@reviewer` audits.
+6. `@content-ops` confirms placement against `docs/content-taxonomy.md`.
+7. `npm run quartz -- build` must exit 0.
+8. Stage explicit paths only → commit → push → open one PR → mark `pr_open`.
+9. Stop. Next run advances to `#74`, then `#75`, `#76`, `#77`.
+
+## Out of Scope for This Queue
+
+- #63 (Mintlify migration) — architectural decision, not a note. Needs its own planning thread.
+- #67 (duplicate title bug) — layout/template fix, belongs to `@content-ops` + Quartz layout review, not the writing queue.


### PR DESCRIPTION
## Summary
- Audits the open issue queue and filters 5 research/writing tasks: #61, #74, #75, #76, #77.
- Records operational requirements per issue (inputs, risks, acceptance) and delegates each to the right agent (`@writer` primary; `@diagram` / `@reviewer` / `@content-ops` as needed).
- Sets the deterministic execution order consumed by `cron/git-auto.md` (one issue per run, lowest number first) — next run picks up #61.

## Filtered Queue

| Order | Issue | Primary Agent | Support |
|-------|-------|---------------|---------|
| 1 | #61 — 小紅書 auto prompt optimizer OSS | `@writer` | `@reviewer` |
| 2 | #74 — Astron Agent / Serper / Jina / Python / LLM | `@writer` | `@reviewer` |
| 3 | #75 — LLM raw/wiki knowledge management | `@writer` | `@diagram`, `@reviewer` |
| 4 | #76 — n8n AI YouTube automation workflow | `@writer` | `@diagram`, `@reviewer` |
| 5 | #77 — cmux terminal multiplexing for Claude Code | `@writer` | `@diagram`, `@reviewer` |

Excluded: #63 (Mintlify migration — architectural, not a note), #67 (layout/bug fix — not a writing task).

## Test plan
- [ ] Review `cron/dispatch-2026-04-13.md` — filter, requirements, and agent map are accurate.
- [ ] Confirm next git-auto run consumes #61 from fresh `origin/main` per workflow rules.
- [ ] Spot-check acceptance criteria match the originating issues.

https://claude.ai/code/session_01WG3toGxnsMX1GV9AuEeocK