### PR TITLE
chore(cron): dispatch research/writing queue for git-auto workflow

### DIFF
--- a/cron/dispatch-2026-04-14.md
+++ b/cron/dispatch-2026-04-14.md
@@ -1,0 +1,58 @@
+# Research & Writing Dispatch — 2026-04-14
+
+Kick-off manifest for `cron/git-auto.md`. Filters the open issue queue down to
+research/writing scope, maps each to the responsible agent from
+`claude/config.yaml`, and records PR coverage so the cron picks the next
+actionable one without duplicating work.
+
+## Filter
+
+Open issues retained — labels `documentation` / `enhancement`, intent =
+research or writing. Operational (site bug, framework migration, infra)
+issues are excluded from this dispatch.
+
+| # | Title (short) | Type | Assigned agent | Open PR |
+|---|---------------|------|----------------|---------|
+| 61 | Prompt auto-optimization 開源專案 | research | `@writer` | #73 |
+| 74 | Astron Agent / Serper / Jina / Python / LLM workflow note | writing | `@writer` | #121 |
+| 75 | LLM raw/wiki 知識管理筆記 | research + writing | `@writer` | #120 |
+| 76 | n8n YouTube automation workflow 研究 | research | `@writer` | — |
+| 77 | cmux / terminal multiplexing × Claude Code 研究 | research | `@writer` | — |
+
+Excluded this run: #63 (Mintlify framework migration — covered by #124),
+#67 (duplicate H1 rendering bug — covered by #68, routed to `@content-ops`).
+
+## Operational requirements per issue
+
+- **#76** — Parse n8n video, break workflow into stages
+  (ideation → script → visuals → voice → assembly → publish → logging),
+  inventory tools per stage, note cost/policy risks, sketch a minimum-viable
+  PoC. Delivers one research note + tool matrix.
+- **#77** — Identify the actual tool referenced by the Xiaohongshu post,
+  compare against `tmux` / `zellij` / `WezTerm mux`, distill a Claude-Code
+  pane layout (agent / logs / edit-git-test / long-running monitor) with
+  constraints. Delivers one research note + comparison table.
+- **#61**, **#74**, **#75** — PR already in flight; this run only confirms
+  coverage. Do not open duplicates.
+
+## Agent routing
+
+All five issues land on `@writer` (see `claude/agents/writer.md`). Rationale:
+
+- Each deliverable is a lean Quartz note under `content/` with frontmatter
+  `title` and kebab-case filename.
+- None require file reorganisation (`@content-ops`), diagram-only work
+  (`@diagram`), or post-hoc audit (`@reviewer`) as the primary task.
+- `@reviewer` runs as a follow-up pass once draft PRs are opened.
+
+## Next cron pick
+
+Per `cron/git-auto.md` rule 4 ("lowest number first, skip if PR open"):
+
+1. Skip #61, #74, #75 — open PRs (#73, #121, #120).
+2. **Pick #76** — branch `auto/issue-76` off fresh `origin/main`, draft
+   the n8n YouTube automation research note with `@writer`, open one PR.
+3. Next run: #77.
+
+Stop after one issue per run. Record status transitions in the tracker
+(`in_progress` → `pr_open` on success, `failed` on validation error).


### PR DESCRIPTION
## Summary
- Audits the open issue queue, filters to 5 research/writing tasks, and maps each to `@writer` per `claude/config.yaml`.
- Confirms PR coverage for #61 (→ #73), #74 (→ #121), #75 (→ #120); flags #76 and #77 as still uncovered.
- Queues **#76** as the next single-issue pick for `cron/git-auto.md` (lowest open number without a PR), then #77 on the following run.

## Filtered queue
| # | Type | Agent | Open PR |
|---|------|-------|---------|
| 61 | research | `@writer` | #73 |
| 74 | writing | `@writer` | #121 |
| 75 | research + writing | `@writer` | #120 |
| 76 | research | `@writer` | — |
| 77 | research | `@writer` | — |

Excluded: #63 (framework migration, covered by #124), #67 (rendering bug, covered by #68 — not research/writing scope).

## Test plan
- [ ] Verify `cron/dispatch-2026-04-14.md` renders correctly on Quartz preview.
- [ ] Confirm next `cron/git-auto.md` run picks #76 and branches `auto/issue-76` off fresh `origin/main`.
- [ ] Ensure no `.automation/` paths are staged in follow-up commits.

https://claude.ai/code/session_01MAiWSVvBaBBj56YY5Ez7ci