### PR TITLE
chore(cron): triage research/writing queue and dispatch #61

### DIFF
--- a/cron/dispatch-2026-04-14.md
+++ b/cron/dispatch-2026-04-14.md
@@ -1,0 +1,119 @@
+---
+title: 研究與寫作 Issue 派工單（2026-04-14）
+---
+
+## 目的
+
+依 `cron/git-auto.md` 所定義的自動化工作流，對目前 open issue queue 進行稽核，
+過濾出屬於「research / writing」的 issue，依技能組合派工給對應 agent，
+並確認本輪（lowest-number first）應執行的 issue。
+
+## 過濾規則
+
+| 規則 | 說明 |
+|------|------|
+| 狀態 | `OPEN` |
+| 類型 | title 含 `Research` / `Write` / `Study note` / `documentation`，或 label 含 `documentation` |
+| 排除 | 工程修復、版面/排版、Quartz layout debug、infra |
+| 重排 | 依 issue number 由小到大 |
+
+符合條件：`#61, #63, #74, #75, #76, #77`
+排除：`#67`（重複標題顯示 — 屬 layout / content convention 修復，非 research/writing）
+
+## Issue 操作需求與派工
+
+### #61 — 研究小紅書「寶藏開源項目，自動優化專業級提示詞」
+
+- **類型**：Research → Note
+- **輸出**：`content/prompt-notes/<kebab-case>.md`（待確認原始專案後命名）
+- **關鍵依賴**：`xhslink.com/o/7iAalKtM6SX` 原文解析（需確認具體 repo）
+- **延伸對照**：DSPy、PromptOptimizer、APE、OPRO、PE-Drive 等 prompt auto-optimization 研究
+- **Primary agent**：`@content-ops`（來源稽核、repo 識別）→ `@writer`（研究摘要成筆記）
+- **Reviewer**：`@reviewer`
+- **Open PR**：無
+- **狀態**：`ready` — 本輪候選
+
+### #63 — Adopt Mintlify as new framework for ai-study-note docs site
+
+- **類型**：Research / Evaluation
+- **輸出**：Mintlify vs Quartz 評估文件、技術選型建議
+- **Primary agent**：`@writer`（框架比較、決策文件）
+- **Reviewer**：`@reviewer`
+- **Open PR**：#124 `docs: Mintlify 框架評估 (closes #63)`
+- **狀態**：`pr_open` — 本輪略過
+
+### #74 — Write study note on Astron Agent / Serper / Jina / Python node / LLM
+
+- **類型**：Writing（使用者已提供整理稿）
+- **輸出**：`content/<topic>/ai-workflow-components.md` 或類似命名
+- **Primary agent**：`@writer`（白話整理 + 工具定位與收費）
+- **Reviewer**：`@reviewer`
+- **Open PR**：#121 `docs: AI workflow 零件分工筆記 (closes #74)`、#103（addresses）
+- **狀態**：`pr_open` — 本輪略過
+
+### #75 — Research learn note on LLM-based knowledge management (raw / wiki)
+
+- **類型**：Research → Note
+- **輸出**：個人 LLM 知識管理工作流研究筆記
+- **Primary agent**：`@writer`（raw/wiki 分離設計說明、工作流圖）
+- **Diagram agent**：`@diagram`（Mermaid LR 工作流圖）
+- **Reviewer**：`@reviewer`
+- **Open PR**：#120 `feat: 個人 LLM 知識管理工作流筆記 (closes #75)`
+- **狀態**：`pr_open` — 本輪略過
+
+### #76 — Research AI-powered YouTube automation workflow (n8n 影片)
+
+- **類型**：Research → Note + 工具清單 + PoC 架構
+- **輸出**：
+  - `content/<topic>/youtube-ai-workflow-research.md`
+  - 工具分類清單（Orchestration / LLM / Visual / Audio / Render / Publish）
+  - 最小 PoC 架構圖（Mermaid LR）
+- **Primary agent**：`@writer`
+- **Diagram agent**：`@diagram`
+- **Reviewer**：`@reviewer`
+- **Open PR**：無
+- **狀態**：`ready`（本輪非最低號，排 #61 之後）
+
+### #77 — Research terminal multiplexing (cmux) for Claude Code
+
+- **類型**：Research → Note + 工具比較表
+- **輸出**：
+  - `content/claude-code/terminal-multiplex-workflow.md`
+  - cmux vs tmux vs zellij vs WezTerm mux 對照
+  - Claude Code 多 pane / 多 session 實務工作流
+- **Primary agent**：`@content-ops`（原始出處與工具身分確認）→ `@writer`
+- **Reviewer**：`@reviewer`
+- **Open PR**：無
+- **狀態**：`ready`（本輪非最低號）
+
+## 派工對照表
+
+| Issue | 類型 | Primary | Diagram | Reviewer | Open PR | 狀態 |
+|-------|------|---------|---------|----------|---------|------|
+| #61 | Research | @content-ops → @writer | — | @reviewer | — | ready ← 本輪 |
+| #63 | Evaluation | @writer | — | @reviewer | #124 | pr_open |
+| #74 | Writing | @writer | — | @reviewer | #121 | pr_open |
+| #75 | Research | @writer | @diagram | @reviewer | #120 | pr_open |
+| #76 | Research | @writer | @diagram | @reviewer | — | ready |
+| #77 | Research | @content-ops → @writer | — | @reviewer | — | ready |
+
+## 本輪選定 Issue（依 `cron/git-auto.md`）
+
+- **選定**：`#61`（lowest number among `ready`）
+- **分支**：`auto/issue-61`（依 git-auto.md 規範）
+- **下一步執行**：
+  1. `git fetch origin && git checkout -B auto/issue-61 origin/main`
+  2. 解析 `xhslink.com/o/7iAalKtM6SX` 或以關鍵字交叉比對，確認對應 repo
+  3. `@content-ops` 寫出來源稽核備忘
+  4. `@writer` 產出 `content/prompt-notes/<kebab-case>.md`
+  5. `@reviewer` 審稿（title frontmatter、kebab-case、Mermaid LR、無 fluff）
+  6. `npm run quartz -- build` 確認 exit 0
+  7. commit（顯式路徑）→ push → 開一支 PR，`closes #61`
+
+## Invariants（重申 `cron/git-auto.md`）
+
+- `.automation/` 一律不 stage、不 commit
+- `git add` 只用明確路徑，禁用 `-A` / `.`
+- 一 issue 一 branch 一 PR，不綑綁無關修復
+- branch 一律從 `origin/main` 重建，不沿用 stale HEAD
+- commit 前 `git diff --cached --stat` 檢查，不含 `.automation/` 或非本 issue 路徑


### PR DESCRIPTION
## Summary

- Audit open issues (`#61, #63, #67, #74, #75, #76, #77`) and filter to the research/writing set: `#61, #63, #74, #75, #76, #77` (excludes `#67` — layout/content-convention fix, not research/writing).
- Analyse each filtered issue's operational requirements and map to the appropriate Claude agent (`@content-ops`, `@writer`, `@diagram`, `@reviewer`) per `claude/config.yaml`.
- Flag issues already covered by open PRs: `#63` (PR #124), `#74` (PR #121 / #103), `#75` (PR #120) — skipped this run to avoid duplicate work.
- Select `#61` as this run's target, following `cron/git-auto.md` rule "pick one open issue, lowest number first". `#61` has no open PR and is ready for `@content-ops` → `@writer` → `@reviewer` pipeline.

## Dispatch table

| Issue | Type | Primary | Diagram | Reviewer | Open PR | Status |
|-------|------|---------|---------|----------|---------|--------|
| #61 | Research | @content-ops → @writer | — | @reviewer | — | ready (this run) |
| #63 | Evaluation | @writer | — | @reviewer | #124 | pr_open |
| #74 | Writing | @writer | — | @reviewer | #121 | pr_open |
| #75 | Research | @writer | @diagram | @reviewer | #120 | pr_open |
| #76 | Research | @writer | @diagram | @reviewer | — | ready |
| #77 | Research | @content-ops → @writer | — | @reviewer | — | ready |

## Next step (per `cron/git-auto.md`)

Spin `auto/issue-61` fresh from `origin/main`, identify the Xiaohongshu source project referenced in `#61`, and deliver a prompt-notes research note through the writer pipeline.

## Test plan

- [ ] Manifest renders under Quartz (kebab-case filename, `title` frontmatter)
- [ ] No `.automation/` paths touched (`git diff --cached --stat` confirmed single file)
- [ ] Branch was cut fresh from `origin/main` (no stale HEAD carry-over)

https://claude.ai/code/session_01EFA55879ffHFof8T18BArM