### PR TITLE
chore(cron): issue triage & agent dispatch for research/writing tasks

### DIFF
--- a/cron/dispatch-2026-04-16.md
+++ b/cron/dispatch-2026-04-16.md
@@ -1,0 +1,96 @@
+# Issue Triage & Agent Dispatch — 2026-04-16
+
+Automated audit of the open issue queue. Filtered for **research** and **writing** tasks, analyzed operational requirements, and delegated to agents per `claude/config.yaml`.
+
+## Triage Summary
+
+| # | Title | Type | Agent | Priority | Status |
+|---|-------|------|-------|----------|--------|
+| 61 | 研究小紅書：寶藏開源項目，自動優化專業級提示詞 | Research | @writer | 1 (lowest number) | Has PR #73 + duplicates |
+| 74 | Write study note on Astron Agent, Serper, Jina AI, Python node, and LLM | Writing | @writer | 2 | Has PR #169 + duplicates |
+| 75 | Research learn note on LLM-based knowledge management (raw/wiki workflow) | Research + Writing | @writer | 3 | Has PR #156 |
+| 76 | Research AI-powered YouTube automation workflow (n8n) | Research | @writer | 4 | Has PR #192 + duplicates |
+| 77 | Research terminal multiplexing workflow for Claude Code productivity | Research | @writer | 5 | Has PR #170 + duplicates |
+
+### Excluded
+
+| # | Title | Reason |
+|---|-------|--------|
+| 67 | Fix duplicate article titles on ai-study-note pages | Bug fix — engineering task, not research/writing |
+
+## Agent Delegation Rationale
+
+All 5 filtered issues produce new content under `content/`. Per the agent registry:
+
+- **@writer** — Primary agent for all 5 issues. Converts research findings and workflows into lean, decision-ready Quartz notes. Composes `formatting.md`, `mermaid.md`, and `quartz.md` prompt fragments.
+- **@content-ops** — Secondary agent. Runs post-write to classify each new note into the taxonomy, assign tags, and verify placement.
+- **@reviewer** — Final pass. Audits each note for technical accuracy, style compliance, and completeness before merge.
+
+### Pipeline per issue
+
+```
+@writer (draft) → @content-ops (classify + place) → @reviewer (QA) → merge
+```
+
+## Operational Requirements
+
+### Issue #61 — Prompt optimization open-source tool research
+- **Input**: 小紅書 link (external Chinese social media post)
+- **Research scope**: Identify the referenced open-source project, evaluate core features, assess fit for ai-study-note
+- **Output**: `content/prompt-notes/<project-name>-research.md`
+- **Deliverables**: Project name, TL;DR, core features, application scenarios, inclusion recommendation
+- **Existing PR**: #73 (auto/issue-61) — review and consolidate
+
+### Issue #74 — AI workflow components study note
+- **Input**: User-provided Telegram notes on Astron Agent, Serper, Jina AI, Python node, LLM
+- **Research scope**: Tool definitions, pricing models, workflow roles
+- **Output**: `content/ai-tools/<kebab-case-title>.md`
+- **Deliverables**: Article with tool taxonomy, pricing summary, workflow diagram
+- **Existing PR**: #169 (auto/issue-74) — review and consolidate
+
+### Issue #75 — LLM-based knowledge management (raw/wiki)
+- **Input**: User's workflow description referencing Karpathy and 林穎俊
+- **Research scope**: Raw/wiki two-layer design, AI-driven summarization, knowledge graph evolution
+- **Output**: `content/knowledge-management/<kebab-case-title>.md`
+- **Deliverables**: Learn note with flow description, raw vs wiki separation value prop, extensibility paths
+- **Existing PR**: #156 — single PR, review for quality
+
+### Issue #76 — AI-powered YouTube automation via n8n
+- **Input**: Japanese YouTube video on n8n-based automation
+- **Research scope**: End-to-end workflow breakdown, tool inventory (30+ tools), PoC architecture
+- **Output**: `content/ai-automation/<kebab-case-title>.md`
+- **Deliverables**: Workflow breakdown, tool classification table, PoC proposal, risk assessment
+- **Existing PR**: #192 — review and consolidate with #154
+
+### Issue #77 — Terminal multiplexing for Claude Code productivity
+- **Input**: 小紅書 post about cmux / terminal workflow
+- **Research scope**: Identify actual tool, compare with tmux/zellij/WezTerm, Claude Code best practices
+- **Output**: `content/dev-tools/<kebab-case-title>.md`
+- **Deliverables**: Tool comparison table, recommended workflow, practical setup guide
+- **Existing PR**: #170 (auto/issue-77) — review and consolidate with #166
+
+## Duplicate PR Alert
+
+Multiple issues have duplicate PRs that should be consolidated:
+
+| Issue | PRs | Recommended | Close |
+|-------|-----|-------------|-------|
+| #61 | #73, #165, #186 | #73 | #165, #186 (partial) |
+| #74 | #169, #164, #185, #186 | #169 | #164, #185, #186 (partial) |
+| #76 | #192, #154, #186 | #192 | #154, #186 (partial) |
+| #77 | #170, #166, #186 | #170 | #166, #186 (partial) |
+| #75 | #156 | #156 | — |
+
+PR #186 is a bulk PR covering multiple issues — violates the "one issue per branch, one branch per PR" invariant from `cron/git-auto.md`. Should be closed.
+
+## Execution Plan
+
+Per `cron/git-auto.md`, process one issue per run, lowest number first:
+
+1. **Run 1**: Review PR #73 for issue #61 → @reviewer audit → merge or request changes
+2. **Run 2**: Review PR #169 for issue #74 → @reviewer audit → merge or request changes
+3. **Run 3**: Review PR #156 for issue #75 → @reviewer audit → merge or request changes
+4. **Run 4**: Review PR #192 for issue #76 → @reviewer audit → merge or request changes
+5. **Run 5**: Review PR #170 for issue #77 → @reviewer audit → merge or request changes
+
+Each run should also close duplicate PRs for that issue.


### PR DESCRIPTION
## Summary

- Audited all 6 open issues, filtered 5 research/writing tasks (#61, #74, #75, #76, #77), excluded #67 (bug fix)
- Delegated each to the `@writer → @content-ops → @reviewer` pipeline based on agent skill sets in `claude/config.yaml`
- Flagged duplicate PRs violating the "one issue per branch, one branch per PR" invariant from `cron/git-auto.md`
- Created execution plan: process issues lowest-number-first, one per run, reviewing existing PRs before creating new work

## Triage Results

| Issue | Type | Agent | Recommended PR | Duplicates to Close |
|-------|------|-------|----------------|---------------------|
| #61 | Research | @writer | #73 | #165, #186 |
| #74 | Writing | @writer | #169 | #164, #185, #186 |
| #75 | Research+Writing | @writer | #156 | — |
| #76 | Research | @writer | #192 | #154, #186 |
| #77 | Research | @writer | #170 | #166, #186 |

## Test plan

- [ ] Verify `cron/dispatch-2026-04-16.md` renders correctly in Quartz
- [ ] Confirm dispatch plan aligns with `cron/git-auto.md` invariants
- [ ] Validate agent assignments match `claude/config.yaml` registry

https://claude.ai/code/session_01HKmvHvMP5P6W8zzQ117Hqw