### PR TITLE
chore(cron): dispatch research/writing issues to @writer agent

### DIFF
--- a/cron/dispatch-2026-04-17.md
+++ b/cron/dispatch-2026-04-17.md
@@ -1,0 +1,65 @@
+# Dispatch: Research & Writing Issues — 2026-04-17
+
+Audit of the open issue queue, filtered for research and writing tasks.
+Delegated per `claude/config.yaml` agent registry. Execution follows `cron/git-auto.md`.
+
+## Filtered Issues (5 of 6 open)
+
+| Issue | Type | Agent | Primary PR | Duplicates | Status |
+|-------|------|-------|------------|------------|--------|
+| #61 — Prompt auto-optimization OSS research | Research | `@writer` | #73 | #165, #186 | `pr_open` |
+| #74 — AI workflow components study note | Writing | `@writer` | #169 | #164, #185, #186 | `pr_open` |
+| #75 — LLM knowledge management (raw/wiki) | Research + Writing | `@writer` | #156 | — | `pr_open` |
+| #76 — YouTube automation with n8n | Research + Writing | `@writer` | #192 | #154, #186 | `pr_open` |
+| #77 — Terminal multiplexing for Claude Code | Research + Writing | `@writer` | #170 | #166, #186 | `pr_open` |
+
+### Excluded
+
+| Issue | Reason |
+|-------|--------|
+| #67 — Fix duplicate article titles | Bug fix (code/template), not research/writing |
+
+## Agent Delegation Rationale
+
+All 5 filtered issues require producing `content/` study notes or research notes.
+The `@writer` agent is the correct match: it composes `formatting.md`, `mermaid.md`,
+and `quartz.md` prompts, and its role is to convert research into lean Quartz notes.
+
+No issues require `@diagram` (no standalone diagram work), `@reviewer` (no existing
+drafts to audit), or `@content-ops` (no bulk file maintenance).
+
+## Operational Requirements
+
+### Per-issue execution (git-auto.md compliance)
+
+Each issue must follow the one-issue-per-branch, one-branch-per-PR invariant:
+
+1. **Preflight**: clean tree, fresh `origin/main` base
+2. **Branch**: `auto/issue-<N>` from `origin/main`
+3. **Implement**: `@writer` produces a Quartz note under `content/`
+4. **Validate**: `npm run quartz -- build` exits 0
+5. **Commit**: stage by explicit path only (never `.automation/`)
+6. **Push + PR**: one PR per issue, referencing `closes #<N>`
+
+### Duplicate PR cleanup required
+
+Issues #61, #74, #76, #77 each have 2–3 duplicate PRs. Before merging, the
+automation runner should:
+
+1. Identify the canonical PR per issue (listed in "Primary PR" above)
+2. Close duplicate PRs with a comment pointing to the canonical one
+3. Verify canonical PR is rebased on current `origin/main`
+
+### Execution order (lowest issue number first)
+
+Per `cron/git-auto.md` §4: pick lowest number first.
+
+1. **#61** — Review PR #73, close duplicates #165 #186
+2. **#74** — Review PR #169, close duplicates #164 #185 #186
+3. **#75** — Review PR #156 (no duplicates)
+4. **#76** — Review PR #192, close duplicates #154 #186
+5. **#77** — Review PR #170, close duplicates #166 #186
+
+## Tracker
+
+Local state in `.automation/issues.json` (never committed per invariant).


### PR DESCRIPTION
## Summary

- Audited all 6 open issues and filtered 5 research/writing tasks (#61, #74, #75, #76, #77)
- Delegated all 5 to `@writer` agent based on `claude/config.yaml` skill mapping
- Documented execution plan in `cron/dispatch-2026-04-17.md` following `cron/git-auto.md` workflow invariants
- Flagged duplicate PRs on 4 of 5 issues requiring cleanup before merge

## Dispatch Summary

| Issue | Type | Agent | Primary PR | Duplicates |
|-------|------|-------|------------|------------|
| #61 | Research | `@writer` | #73 | #165, #186 |
| #74 | Writing | `@writer` | #169 | #164, #185, #186 |
| #75 | Research + Writing | `@writer` | #156 | — |
| #76 | Research + Writing | `@writer` | #192 | #154, #186 |
| #77 | Research + Writing | `@writer` | #170 | #166, #186 |

**Excluded:** #67 (bug fix, not research/writing)

## Execution Order

Per `cron/git-auto.md` §4 (lowest issue number first): #61 → #74 → #75 → #76 → #77

## Next Steps

1. Review and close duplicate PRs per issue
2. Rebase canonical PRs onto current `origin/main`
3. Run `@writer` agent on any issues needing content revision
4. Validate each with `npm run quartz -- build`

https://claude.ai/code/session_014YM393JHUmpKWJqLxnokEK