### PR TITLE
feat(cron): dispatch manifest for research/writing issues

### DIFF
--- a/cron/dispatch-2026-04-17.md
+++ b/cron/dispatch-2026-04-17.md
@@ -1,0 +1,82 @@
+# Issue Queue Dispatch — 2026-04-17
+
+Audit of open issues filtered for research and writing tasks, with agent delegation per `claude/config.yaml`.
+
+## Filtered Issues (Research / Writing)
+
+| Priority | Issue | Type | Primary Agent | Title |
+|----------|-------|------|---------------|-------|
+| 1 | #61 | Research | `@writer` | 研究小紅書：寶藏開源項目，自動優化專業級提示詞 |
+| 2 | #74 | Writing | `@writer` | Write study note on Astron Agent, Serper, Jina AI, Python node, and LLM |
+| 3 | #75 | Research + Writing | `@writer` | Research learn note on LLM-based knowledge management with raw and wiki workflow |
+| 4 | #76 | Research + Writing | `@writer` | Research AI-powered YouTube automation workflow from n8n video |
+| 5 | #77 | Research + Writing | `@writer` | Research terminal multiplexing workflow that boosts Claude Code productivity |
+
+## Excluded Issues
+
+| Issue | Title | Reason |
+|-------|-------|--------|
+| #67 | Fix duplicate article titles on ai-study-note pages | Bug fix — requires template/layout engineering, not research or writing |
+
+## Agent Delegation
+
+Each filtered issue follows a three-stage pipeline:
+
+```
+@writer → @reviewer → @content-ops
+```
+
+| Stage | Agent | Responsibility |
+|-------|-------|----------------|
+| 1 | `@writer` | Research source material, draft study note under `content/` |
+| 2 | `@reviewer` | Audit for accuracy, style compliance, completeness |
+| 3 | `@content-ops` | Classify per taxonomy, place in correct folder, set frontmatter tags |
+
+## Operational Requirements per Issue
+
+### #61 — Open-source prompt optimization research
+- **Input**: Xiaohongshu link (external content, may require web research fallback)
+- **Output**: `content/<topic>/prompt-optimization-open-source.md`
+- **Requires**: Web research to identify the actual project/repo
+- **Risk**: Source link may be inaccessible; need alternative research path
+
+### #74 — AI workflow tools study note
+- **Input**: User-provided notes on Astron Agent, Serper, Jina AI, Python node, LLM
+- **Output**: `content/<topic>/ai-workflow-tools-astron-serper-jina.md`
+- **Requires**: Tool documentation review, pricing verification
+- **Risk**: Low — well-scoped with clear deliverables
+
+### #75 — LLM-based knowledge management (raw/wiki)
+- **Input**: User-provided workflow description, references to Karpathy and 林穎俊
+- **Output**: `content/<topic>/llm-knowledge-management-raw-wiki.md`
+- **Requires**: Understanding of raw/wiki separation pattern
+- **Risk**: Low — source material provided in issue body
+
+### #76 — AI-powered YouTube automation via n8n
+- **Input**: YouTube video (Japanese), tool inventory in issue body
+- **Output**: `content/<topic>/ai-youtube-automation-n8n.md` + tool comparison table
+- **Requires**: Video content analysis, tool documentation cross-reference
+- **Risk**: Medium — large scope with 20+ tools to document; may need multiple commits
+
+### #77 — Terminal multiplexing for Claude Code
+- **Input**: Xiaohongshu link, references to cmux/tmux/zellij
+- **Output**: `content/<topic>/terminal-multiplexing-claude-code.md` + comparison table
+- **Requires**: Tool research, Claude Code workflow best practices
+- **Risk**: Low-medium — need to confirm what "cmux" actually refers to
+
+## Execution Protocol
+
+Per `cron/git-auto.md`:
+- One issue per run, lowest number first
+- Branch fresh from `origin/main` as `auto/issue-<number>`
+- Stage files by explicit path only (never `git add .`)
+- `.automation/issues.json` tracks state locally (never committed)
+- Each issue gets exactly one PR
+
+### Execution Order
+
+1. `auto/issue-61` — #61 (research)
+2. `auto/issue-74` — #74 (writing)
+3. `auto/issue-75` — #75 (research + writing)
+4. `auto/issue-76` — #76 (research + writing)
+5. `auto/issue-77` — #77 (research + writing)


### PR DESCRIPTION
## Summary

- Audited the full open issue queue (6 issues) and filtered **5 research/writing tasks** (#61, #74, #75, #76, #77)
- Excluded #67 (bug fix — layout engineering, not research/writing)
- Delegated all 5 to a three-stage agent pipeline: `@writer` → `@reviewer` → `@content-ops`
- Documented operational requirements, risks, and execution order per `cron/git-auto.md`

## Dispatch Overview

| Priority | Issue | Type | Agent Pipeline |
|----------|-------|------|----------------|
| 1 | #61 | Research | `@writer` → `@reviewer` → `@content-ops` |
| 2 | #74 | Writing | `@writer` → `@reviewer` → `@content-ops` |
| 3 | #75 | Research + Writing | `@writer` → `@reviewer` → `@content-ops` |
| 4 | #76 | Research + Writing | `@writer` → `@reviewer` → `@content-ops` |
| 5 | #77 | Research + Writing | `@writer` → `@reviewer` → `@content-ops` |

## What This PR Contains

- `cron/dispatch-2026-04-17.md` — Full dispatch manifest with issue analysis, agent delegation, operational requirements per issue, and execution order
- `.automation/issues.json` created locally (gitignored, never committed) as the state tracker for `cron/git-auto.md`

## Test plan

- [ ] Verify `cron/dispatch-2026-04-17.md` accurately reflects open issues
- [ ] Confirm `.automation/issues.json` is not included in the diff
- [ ] Validate agent assignments match `claude/config.yaml` capabilities
- [ ] Review execution order follows lowest-number-first per `cron/git-auto.md`

https://claude.ai/code/session_01XKZMoprmQTDFowNrcDDmak