### PR TITLE
Add Garry Tan to people directory

### DIFF
--- a/src/data/people.ts
+++ b/src/data/people.ts
@@ -56,6 +56,16 @@ export const PEOPLE = [
       { label: "Twitter / X", url: "https://x.com/thedankoe" },
     ],
   },
+  {
+    slug: "garry-tan",
+    displayName: "Garry Tan",
+    bio: "Y Combinator 總裁暨執行長，前 Initialized Capital 共同創辦人，Coinbase、Instacart 等公司的早期投資人。經營 YouTube 頻道分享創業與新創建造心法，以實作導向的創業建議著稱。",
+    links: [
+      { label: "Y Combinator", url: "https://www.ycombinator.com/" },
+      { label: "Twitter / X", url: "https://x.com/garrytan" },
+      { label: "YouTube", url: "https://www.youtube.com/@garrytan" },
+    ],
+  },
 ] as const satisfies readonly Person[];
 
 export type PersonSlug = (typeof PEOPLE)[number]["slug"];


### PR DESCRIPTION
## Summary
Added Garry Tan to the people directory with his bio and social links.

## Changes
- Added new person entry for Garry Tan (`garry-tan` slug) to `src/data/people.ts`
- Included Traditional Chinese bio describing his role as Y Combinator President & CEO, early investor background, and YouTube presence
- Added three social/professional links: Y Combinator, Twitter/X, and YouTube channel

## Details
The entry follows the existing `Person` type structure with:
- **slug**: `garry-tan` (kebab-case identifier)
- **displayName**: `Garry Tan`
- **bio**: zh-tw description of his background and expertise
- **links**: Array of three relevant URLs (Y Combinator, Twitter/X, YouTube)

https://claude.ai/code/session_01QkTqGnoaH4P1wmBrRtxGxg