### PR TITLE
Add category display labels for header navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,6 +4,13 @@ import { getCollection } from "astro:content";
 const base = import.meta.env.BASE_URL;
 const posts = await getCollection("blog", ({ data }) => !data.draft);
 const categories = [...new Set(posts.map((p) => p.data.category))].sort();
+const categoryLabels: Record<string, string> = {
+  "claude-code": "Claude Code",
+  openclaw: "OpenClaw",
+  "prompt-notes": "提示詞筆記",
+  "seo-and-geo": "SEO 與 GEO",
+  "setup-env": "環境設定",
+};
 const current = Astro.url.pathname;
 const isActive = (path: string) =>
   path === base ? current === base || current === base.slice(0, -1) : current.startsWith(path);
@@ -50,7 +57,7 @@ const isActive = (path: string) =>
           <a
             href={`${base}categories/${c}/`}
             class={`hover:text-accent transition-colors ${current === `${base}categories/${c}/` ? "text-accent" : ""}`}
-          >{c}</a>
+          >{categoryLabels[c] ?? c}</a>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
Add human-readable display labels for blog categories in the header navigation, mapping internal category slugs to localized Chinese names.

## Changes
- **Added `categoryLabels` mapping** in `Header.astro` with translations for all five categories:
  - `claude-code` → "Claude Code"
  - `openclaw` → "OpenClaw"
  - `prompt-notes` → "提示詞筆記"
  - `seo-and-geo` → "SEO 與 GEO"
  - `setup-env` → "環境設定"

- **Updated category link rendering** to use `categoryLabels[c] ?? c` instead of displaying the raw slug, providing a fallback to the original slug if a label is missing

## Implementation Details
The mapping uses TypeScript's `Record<string, string>` type for type safety. The nullish coalescing operator (`??`) ensures graceful degradation if a category slug is missing from the labels object, maintaining backward compatibility and preventing broken displays.

This aligns with the site's zh-tw language convention by displaying category names in Traditional Chinese to Taiwanese readers while keeping internal identifiers in English kebab-case.

https://claude.ai/code/session_012PyPx91wDJsHiEN79rAosT